### PR TITLE
Feat: 관리자 또는 사용자의 로그인/로그아웃

### DIFF
--- a/src/main/java/com/ureca/ufit/domain/user/controller/UserController.java
+++ b/src/main/java/com/ureca/ufit/domain/user/controller/UserController.java
@@ -1,14 +1,25 @@
 package com.ureca.ufit.domain.user.controller;
 
+import com.ureca.ufit.domain.user.dto.request.RegisterRequest;
+import com.ureca.ufit.domain.user.dto.response.RegisterResponse;
+import com.ureca.ufit.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.ureca.ufit.domain.user.service.UserService;
-
-import lombok.RequiredArgsConstructor;
-
 @RestController
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class UserController {
 
-	private final UserService userService;
+    private final UserService userService;
+
+    @PostMapping("/users/register")
+    public ResponseEntity<RegisterResponse> register(@RequestBody RegisterRequest registerRequest) {
+        return ResponseEntity.ok(userService.register(registerRequest));
+    }
+
 }

--- a/src/main/java/com/ureca/ufit/domain/user/dto/UserMapper.java
+++ b/src/main/java/com/ureca/ufit/domain/user/dto/UserMapper.java
@@ -1,0 +1,17 @@
+package com.ureca.ufit.domain.user.dto;
+
+
+import com.ureca.ufit.domain.user.dto.request.RegisterRequest;
+import com.ureca.ufit.entity.User;
+
+public class UserMapper {
+    public static User toEntity(RegisterRequest loginRequest, String encodePassword) {
+        return User.of(loginRequest.email(),
+                encodePassword,
+                loginRequest.age(),
+                loginRequest.family(),
+                loginRequest.gender(),
+                loginRequest.role(),
+                loginRequest.ratePlanId());
+    }
+}

--- a/src/main/java/com/ureca/ufit/domain/user/dto/request/LoginRequest.java
+++ b/src/main/java/com/ureca/ufit/domain/user/dto/request/LoginRequest.java
@@ -1,0 +1,9 @@
+package com.ureca.ufit.domain.user.dto.request;
+
+
+public record LoginRequest(
+        String email,
+        String password
+)
+{
+}

--- a/src/main/java/com/ureca/ufit/domain/user/dto/request/RegisterRequest.java
+++ b/src/main/java/com/ureca/ufit/domain/user/dto/request/RegisterRequest.java
@@ -1,0 +1,16 @@
+package com.ureca.ufit.domain.user.dto.request;
+
+import com.ureca.ufit.entity.enums.Gender;
+import com.ureca.ufit.entity.enums.Role;
+
+public record RegisterRequest(
+        String email,
+        String password,
+        int age,
+        int family,
+        Gender gender,
+        Role role,
+        String ratePlanId
+) {
+
+}

--- a/src/main/java/com/ureca/ufit/domain/user/dto/request/RegisterRequest.java
+++ b/src/main/java/com/ureca/ufit/domain/user/dto/request/RegisterRequest.java
@@ -3,13 +3,34 @@ package com.ureca.ufit.domain.user.dto.request;
 import com.ureca.ufit.entity.enums.Gender;
 import com.ureca.ufit.entity.enums.Role;
 
+import jakarta.validation.constraints.*;
+
 public record RegisterRequest(
+        @Email(message = "이메일 형식이 아닙니다.")
+        @NotBlank(message = "이메일은 필수입니다.")
         String email,
+
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        @Size(min = 8, max = 15, message = "비밀번호는 8~15자 사이여야 합니다.")
+        @Pattern(
+                regexp = "^(?=(?:.*[!@#$%^&*(),.?\":{}|<>\\[\\]\\/\\\\~`_+=\\-]){3,})(?=.*[a-z]).{6,}$",
+                message = "비밀번호는 특수문자 3개 이상과 영문 소문자 1자 이상을 포함해야 합니다."
+        )
         String password,
+
+        @Min(value = 1, message = "나이는 1세 이상이어야 합니다.")
         int age,
+
+        @Min(value = 1, message = "가구원 수는 최소 1명 이상이어야 합니다.")
         int family,
+
+        @NotNull(message = "성별을 선택해주세요.")
         Gender gender,
+
+        @NotNull(message = "권한을 설정해주세요.")
         Role role,
+
+        @NotBlank(message = "요금제 ID는 필수입니다.")
         String ratePlanId
 ) {
 

--- a/src/main/java/com/ureca/ufit/domain/user/dto/response/LoginResponse.java
+++ b/src/main/java/com/ureca/ufit/domain/user/dto/response/LoginResponse.java
@@ -1,0 +1,26 @@
+package com.ureca.ufit.domain.user.dto.response;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import com.ureca.ufit.entity.enums.Role;
+import lombok.Builder;
+
+@Builder
+public record LoginResponse(
+        String email,
+        Role role
+) {
+
+    @Builder(access = PRIVATE)
+    public LoginResponse(String email, Role role){
+        this.email = email;
+        this.role = role;
+    }
+
+    public static LoginResponse of(String email, Role role){
+        return LoginResponse.builder()
+                .email(email)
+                .role(role)
+                .build();
+    }
+}

--- a/src/main/java/com/ureca/ufit/domain/user/dto/response/RegisterResponse.java
+++ b/src/main/java/com/ureca/ufit/domain/user/dto/response/RegisterResponse.java
@@ -1,0 +1,7 @@
+package com.ureca.ufit.domain.user.dto.response;
+
+public record RegisterResponse(
+        boolean success
+) {
+
+}

--- a/src/main/java/com/ureca/ufit/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/ureca/ufit/domain/user/exception/UserErrorCode.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 public enum UserErrorCode implements ErrorCode {
 
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다."),
+	USER_PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호가 틀렸습니다.")
 	;
 
 	private final HttpStatus httpStatus;

--- a/src/main/java/com/ureca/ufit/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/ureca/ufit/domain/user/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.ureca.ufit.domain.user.repository;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -7,5 +8,5 @@ import com.ureca.ufit.entity.User;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/ureca/ufit/domain/user/service/UserService.java
+++ b/src/main/java/com/ureca/ufit/domain/user/service/UserService.java
@@ -1,14 +1,40 @@
 package com.ureca.ufit.domain.user.service;
 
+import com.ureca.ufit.domain.user.dto.request.RegisterRequest;
+import com.ureca.ufit.domain.user.dto.response.RegisterResponse;
+import com.ureca.ufit.entity.User;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import com.ureca.ufit.domain.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
 
 	private final UserRepository userRepository;
+	private final PasswordEncoder passwordEncoder;
+
+
+	//DB 확인용 회원가입
+	@Transactional
+	public RegisterResponse register(RegisterRequest request) {
+		String encodedPassword = passwordEncoder.encode(request.password());
+
+		User user = User.of(request.email(),
+				encodedPassword,
+				request.age(),
+				request.family(),
+				request.gender(),
+				request.role(),
+				request.ratePlanId());
+		userRepository.save(user);
+
+		return new RegisterResponse(true);
+	}
+
+
 }

--- a/src/main/java/com/ureca/ufit/domain/user/service/UserService.java
+++ b/src/main/java/com/ureca/ufit/domain/user/service/UserService.java
@@ -1,8 +1,8 @@
 package com.ureca.ufit.domain.user.service;
 
+import com.ureca.ufit.domain.user.dto.UserMapper;
 import com.ureca.ufit.domain.user.dto.request.RegisterRequest;
 import com.ureca.ufit.domain.user.dto.response.RegisterResponse;
-import com.ureca.ufit.entity.User;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -18,21 +18,11 @@ public class UserService {
 	private final UserRepository userRepository;
 	private final PasswordEncoder passwordEncoder;
 
-
 	//DB 확인용 회원가입
 	@Transactional
 	public RegisterResponse register(RegisterRequest request) {
 		String encodedPassword = passwordEncoder.encode(request.password());
-
-		User user = User.of(request.email(),
-				encodedPassword,
-				request.age(),
-				request.family(),
-				request.gender(),
-				request.role(),
-				request.ratePlanId());
-		userRepository.save(user);
-
+		userRepository.save(UserMapper.toEntity(request, encodedPassword));
 		return new RegisterResponse(true);
 	}
 

--- a/src/main/java/com/ureca/ufit/entity/RefreshToken.java
+++ b/src/main/java/com/ureca/ufit/entity/RefreshToken.java
@@ -1,0 +1,37 @@
+package com.ureca.ufit.entity;
+
+import static com.ureca.ufit.global.auth.util.JwtUtil.REFRESH_TOKEN_PREFIX;
+import static lombok.AccessLevel.PRIVATE;
+import static lombok.AccessLevel.PROTECTED;
+
+import com.ureca.ufit.global.auth.util.JwtUtil;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@RedisHash(value = REFRESH_TOKEN_PREFIX, timeToLive = JwtUtil.REFRESH_TOKEN_EXPIRED_MS)
+@Getter
+@Builder
+@NoArgsConstructor(access = PROTECTED)
+public class RefreshToken {
+
+    @Id
+    private String refreshToken;
+
+    private String email;
+
+    @Builder(access = PRIVATE)
+    public RefreshToken(String refreshToken, String email) {
+        this.refreshToken = refreshToken;
+        this.email = email;
+    }
+
+    public static RefreshToken of(String refreshToken, String email) {
+        return RefreshToken.builder()
+                .refreshToken(refreshToken)
+                .email(email)
+                .build();
+    }
+}

--- a/src/main/java/com/ureca/ufit/entity/User.java
+++ b/src/main/java/com/ureca/ufit/entity/User.java
@@ -37,7 +37,6 @@ public class User extends TimeBaseEntity {
 	@Column(name = "email", nullable = false)
 	private String email;
 
-	@Size(max = 50)
 	@NotNull
 	@Column(name = "password", nullable = false)
 	private String password;
@@ -74,5 +73,17 @@ public class User extends TimeBaseEntity {
 		this.gender = gender;
 		this.role = role;
 		this.ratePlanId = ratePlanId;
+	}
+
+	public static User of(String email, String password, int age, int family, Gender gender, Role role, String ratePlanId){
+		return User.builder()
+				.email(email)
+				.password(password)
+				.age(age)
+				.family(family)
+				.gender(gender)
+				.role(role)
+				.ratePlanId(ratePlanId)
+				.build();
 	}
 }

--- a/src/main/java/com/ureca/ufit/entity/User.java
+++ b/src/main/java/com/ureca/ufit/entity/User.java
@@ -34,7 +34,7 @@ public class User extends TimeBaseEntity {
 
 	@Size(max = 50)
 	@NotNull
-	@Column(name = "email", nullable = false)
+	@Column(name = "email", nullable = false, unique = true)
 	private String email;
 
 	@NotNull

--- a/src/main/java/com/ureca/ufit/global/auth/contoller/AuthController.java
+++ b/src/main/java/com/ureca/ufit/global/auth/contoller/AuthController.java
@@ -1,0 +1,36 @@
+package com.ureca.ufit.global.auth.contoller;
+
+import static com.ureca.ufit.global.auth.util.JwtUtil.AUTH_HEADER;
+import static com.ureca.ufit.global.auth.util.JwtUtil.BEARER_PREFIX;
+import static com.ureca.ufit.global.auth.util.JwtUtil.REFRESH_TOKEN_COOKIE_NAME;
+
+import com.ureca.ufit.global.auth.service.AuthService;
+import com.ureca.ufit.global.exception.CommonErrorCode;
+import com.ureca.ufit.global.exception.RestApiException;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/reissue/token")
+    public ResponseEntity<?> reissueToken(
+            @CookieValue(name = REFRESH_TOKEN_COOKIE_NAME) String refreshToken,
+            @RequestHeader(name = AUTH_HEADER) String bearerToken,
+            HttpServletResponse response
+    ) {
+        authService.reissueToken(bearerToken, refreshToken, response);
+        return ResponseEntity.ok().build();
+    }
+
+}

--- a/src/main/java/com/ureca/ufit/global/auth/contoller/AuthController.java
+++ b/src/main/java/com/ureca/ufit/global/auth/contoller/AuthController.java
@@ -1,12 +1,9 @@
 package com.ureca.ufit.global.auth.contoller;
 
 import static com.ureca.ufit.global.auth.util.JwtUtil.AUTH_HEADER;
-import static com.ureca.ufit.global.auth.util.JwtUtil.BEARER_PREFIX;
 import static com.ureca.ufit.global.auth.util.JwtUtil.REFRESH_TOKEN_COOKIE_NAME;
 
 import com.ureca.ufit.global.auth.service.AuthService;
-import com.ureca.ufit.global.exception.CommonErrorCode;
-import com.ureca.ufit.global.exception.RestApiException;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -24,7 +21,7 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/reissue/token")
-    public ResponseEntity<?> reissueToken(
+    public ResponseEntity<Void> reissueToken(
             @CookieValue(name = REFRESH_TOKEN_COOKIE_NAME) String refreshToken,
             @RequestHeader(name = AUTH_HEADER) String bearerToken,
             HttpServletResponse response

--- a/src/main/java/com/ureca/ufit/global/auth/details/CustomUserDetails.java
+++ b/src/main/java/com/ureca/ufit/global/auth/details/CustomUserDetails.java
@@ -1,0 +1,35 @@
+package com.ureca.ufit.global.auth.details;
+
+import com.ureca.ufit.entity.enums.Role;
+import java.util.Collection;
+import java.util.List;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+
+public record CustomUserDetails(
+        String email,
+        String password,
+        Role role
+
+) implements UserDetails {
+
+    private static final String PREFIX_ROLE = "ROLE_";
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(PREFIX_ROLE + role.name()));
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+}

--- a/src/main/java/com/ureca/ufit/global/auth/filter/ExceptionHandlerFilter.java
+++ b/src/main/java/com/ureca/ufit/global/auth/filter/ExceptionHandlerFilter.java
@@ -1,0 +1,28 @@
+package com.ureca.ufit.global.auth.filter;
+
+import com.ureca.ufit.global.auth.util.SendErrorResponseUtil;
+import com.ureca.ufit.global.exception.CommonErrorCode;
+import com.ureca.ufit.global.exception.RestApiException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class ExceptionHandlerFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain) throws IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (RestApiException e) {
+            SendErrorResponseUtil.sendErrorResponse(response, e.getErrorCode());
+        } catch (Exception e) {
+            SendErrorResponseUtil.sendErrorResponse(response, CommonErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/ureca/ufit/global/auth/filter/JwtFilter.java
+++ b/src/main/java/com/ureca/ufit/global/auth/filter/JwtFilter.java
@@ -1,0 +1,95 @@
+package com.ureca.ufit.global.auth.filter;
+
+import static com.ureca.ufit.global.auth.util.JwtUtil.AUTH_HEADER;
+import static com.ureca.ufit.global.auth.util.JwtUtil.BEARER_PREFIX;
+import static com.ureca.ufit.global.auth.util.JwtUtil.BLACKLIST_PREFIX;
+
+import com.ureca.ufit.global.auth.service.CustomUserDetailsService;
+import com.ureca.ufit.global.auth.util.JwtUtil;
+import com.ureca.ufit.global.exception.CommonErrorCode;
+import com.ureca.ufit.global.exception.RestApiException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import javax.crypto.SecretKey;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+    // 비회원 회원 모두 JWT검증 필요X
+    private static final List<String> WHITE_LIST = List.of(
+            "/error", "/favicon.ico", "/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html",
+            "/api/auth/login",
+            "/api/users/register",
+            "/api/rateplans/storages/**",
+            "/api/auth/reissue/token"
+    );
+
+    // 비회원이면 JWT검증 필요X, 회원이면  JWT검증 필요
+    private static final List<String> PUBLIC_LIST = List.of(
+            "/api/chats/message",
+            "/api/chats/messages/ai",
+            "/api/chats/review",
+            "/api/chats"
+    );
+
+    private static final AntPathMatcher matcher = new AntPathMatcher();
+
+    private final CustomUserDetailsService userDetailsService;
+    private final RedisTemplate<String,String> redisTemplate;
+    private final SecretKey secretKey;
+
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+
+        boolean isPublic = PUBLIC_LIST.stream().anyMatch(pub -> matcher.match(pub, request.getRequestURI()));
+
+        // 어세스 토큰 유효성 검사 시작
+        String bearerToken = request.getHeader(AUTH_HEADER);
+        if (bearerToken != null && bearerToken.startsWith(BEARER_PREFIX)) {
+
+            String accessToken = bearerToken.substring(7);
+
+            // 어세스 토큰 검증, 블랙 리스트 확인
+            JwtUtil.validateAccessToken(accessToken, secretKey);
+            if (Boolean.TRUE.equals(redisTemplate.hasKey(BLACKLIST_PREFIX + accessToken))) {
+                throw new RestApiException(CommonErrorCode.INVALID_TOKEN);
+            }
+
+            // 인증 객체를 설정하고 시큐리티 홀더에 저장
+            String email = JwtUtil.getEmail(accessToken, secretKey);
+            UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+            Authentication authentication = new UsernamePasswordAuthenticationToken(
+                    userDetails, null, userDetails.getAuthorities()
+            );
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        } else {
+            if (!isPublic) {
+                throw new RestApiException(CommonErrorCode.NOT_EXIST_BEARER_SUFFIX);
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        return WHITE_LIST.stream().anyMatch(white -> matcher.match(white, request.getRequestURI()));
+    }
+}

--- a/src/main/java/com/ureca/ufit/global/auth/filter/JwtFilter.java
+++ b/src/main/java/com/ureca/ufit/global/auth/filter/JwtFilter.java
@@ -63,7 +63,7 @@ public class JwtFilter extends OncePerRequestFilter {
         String bearerToken = request.getHeader(AUTH_HEADER);
         if (bearerToken != null && bearerToken.startsWith(BEARER_PREFIX)) {
 
-            String accessToken = bearerToken.substring(7);
+            String accessToken = bearerToken.substring(BEARER_PREFIX.length());
 
             // 어세스 토큰 검증, 블랙 리스트 확인
             JwtUtil.validateAccessToken(accessToken, secretKey);

--- a/src/main/java/com/ureca/ufit/global/auth/filter/LoginFilter.java
+++ b/src/main/java/com/ureca/ufit/global/auth/filter/LoginFilter.java
@@ -1,0 +1,36 @@
+package com.ureca.ufit.global.auth.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ureca.ufit.domain.user.dto.request.LoginRequest;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+
+public class LoginFilter extends AbstractAuthenticationProcessingFilter {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public LoginFilter() {
+        super(new AntPathRequestMatcher("/api/auth/login", "POST"));
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request,
+            HttpServletResponse response)
+            throws AuthenticationException, IOException {
+
+        LoginRequest loginRequest =  objectMapper.readValue(request.getInputStream(), LoginRequest.class);
+        String email = loginRequest.email();
+        String password = loginRequest.password();
+
+        Authentication authentication = new UsernamePasswordAuthenticationToken(email, password);
+
+        // 인증 메니저에게 인증 객체 위임
+        return this.getAuthenticationManager().authenticate(authentication);
+    }
+}

--- a/src/main/java/com/ureca/ufit/global/auth/handler/CustomLoginSuccessHandler.java
+++ b/src/main/java/com/ureca/ufit/global/auth/handler/CustomLoginSuccessHandler.java
@@ -39,7 +39,7 @@ public class CustomLoginSuccessHandler implements AuthenticationSuccessHandler {
         refreshTokenRepository.save(refreshTokenEntity);
 
         // 쿠키에 리프레시 토큰 저장 (timeout 3일)
-        JwtUtil.setRefreshTokenCookie(response, refreshToken, REFRESH_TOKEN_EXPIRED_MS /1000);
+        JwtUtil.updateRefreshTokenCookie(response, refreshToken, REFRESH_TOKEN_EXPIRED_MS /1000);
 
         // 헤더에 어세스 토큰 저장
         response.setHeader(AUTH_HEADER, BEARER_PREFIX + accessToken);

--- a/src/main/java/com/ureca/ufit/global/auth/handler/CustomLoginSuccessHandler.java
+++ b/src/main/java/com/ureca/ufit/global/auth/handler/CustomLoginSuccessHandler.java
@@ -18,7 +18,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class LoginSuccessHandler implements AuthenticationSuccessHandler {
+public class CustomLoginSuccessHandler implements AuthenticationSuccessHandler {
 
     private final SecretKey secretKeyKey;
     private final RefreshTokenRepository refreshTokenRepository;

--- a/src/main/java/com/ureca/ufit/global/auth/handler/CustomLoginSuccessHandler.java
+++ b/src/main/java/com/ureca/ufit/global/auth/handler/CustomLoginSuccessHandler.java
@@ -4,12 +4,15 @@ import static com.ureca.ufit.global.auth.util.JwtUtil.AUTH_HEADER;
 import static com.ureca.ufit.global.auth.util.JwtUtil.BEARER_PREFIX;
 import static com.ureca.ufit.global.auth.util.JwtUtil.REFRESH_TOKEN_EXPIRED_MS;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ureca.ufit.domain.user.dto.response.LoginResponse;
 import com.ureca.ufit.entity.RefreshToken;
 import com.ureca.ufit.global.auth.details.CustomUserDetails;
 import com.ureca.ufit.global.auth.repository.RefreshTokenRepository;
 import com.ureca.ufit.global.auth.util.JwtUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import javax.crypto.SecretKey;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
@@ -22,10 +25,12 @@ public class CustomLoginSuccessHandler implements AuthenticationSuccessHandler {
 
     private final SecretKey secretKeyKey;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final ObjectMapper objectMapper;
+
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
-            Authentication authentication) {
+            Authentication authentication) throws IOException {
 
         // 로그인 성공 시 인증 객체의 principal을 정의하기 위한 유저 정보
         CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
@@ -43,6 +48,10 @@ public class CustomLoginSuccessHandler implements AuthenticationSuccessHandler {
 
         // 헤더에 어세스 토큰 저장
         response.setHeader(AUTH_HEADER, BEARER_PREFIX + accessToken);
+
+        // 바디에 Login Response 저장
+        LoginResponse loginResponse = LoginResponse.of(userDetails.getUsername(),userDetails.role());
+        objectMapper.writeValue(response.getWriter(), loginResponse);
     }
 
 }

--- a/src/main/java/com/ureca/ufit/global/auth/handler/CustomLogoutHandler.java
+++ b/src/main/java/com/ureca/ufit/global/auth/handler/CustomLogoutHandler.java
@@ -1,0 +1,62 @@
+package com.ureca.ufit.global.auth.handler;
+
+import static com.ureca.ufit.global.auth.util.JwtUtil.AUTH_HEADER;
+import static com.ureca.ufit.global.auth.util.JwtUtil.BEARER_PREFIX;
+import static com.ureca.ufit.global.auth.util.JwtUtil.BLACKLIST_PREFIX;
+
+import com.ureca.ufit.global.auth.repository.RefreshTokenRepository;
+import com.ureca.ufit.global.auth.util.JwtUtil;
+import com.ureca.ufit.global.exception.CommonErrorCode;
+import com.ureca.ufit.global.exception.RestApiException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+import javax.crypto.SecretKey;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CustomLogoutHandler implements LogoutHandler {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final RedisTemplate<String,String> redisTemplate;
+    private final SecretKey secretKey;
+
+    @Override
+    public void logout(HttpServletRequest request, HttpServletResponse response,
+            Authentication authentication) {
+
+        // 로그아웃 시 헤더에 있는 어세스 토큰 검증
+        String bearerToken = request.getHeader(AUTH_HEADER);
+        if( bearerToken == null || !bearerToken.startsWith(BEARER_PREFIX)){
+            throw new RestApiException(CommonErrorCode.NOT_EXIST_BEARER_SUFFIX);
+        }
+        String accessToken = bearerToken.substring(7);
+        JwtUtil.validateAccessToken(accessToken, secretKey);
+
+        // 블랙 리스트에 어세스 토큰 추가
+        addToBlacklistRedis(accessToken);
+
+        // 레디스에서 리프레시 토큰 삭제
+        String refreshToken = JwtUtil.getRefreshTokenCookies(request);
+        if (refreshToken != null) {
+            // Redis에서 해당 리프레시 토큰 키 삭제
+            refreshTokenRepository.findById(refreshToken)
+                    .ifPresent(refreshTokenRepository::delete);
+        }
+
+        // 쿠키에서 리프레시 토큰 삭제 (timeout을 0으로 두어 즉시 삭제)
+        JwtUtil.setRefreshTokenCookie(response, null, 0);
+    }
+
+    private void addToBlacklistRedis(String accessToken) {
+        Date expiration = JwtUtil.getExpiration(accessToken, secretKey);
+        long ttl = expiration.getTime() - System.currentTimeMillis(); // TTL: 남은 시간 - 현재 시간
+        redisTemplate.opsForValue().set(BLACKLIST_PREFIX + accessToken, "logout", ttl, TimeUnit.MILLISECONDS);
+    }
+}

--- a/src/main/java/com/ureca/ufit/global/auth/handler/CustomLogoutHandler.java
+++ b/src/main/java/com/ureca/ufit/global/auth/handler/CustomLogoutHandler.java
@@ -39,7 +39,7 @@ public class CustomLogoutHandler implements LogoutHandler {
             if (bearerToken == null || !bearerToken.startsWith(BEARER_PREFIX)) {
                 throw new RestApiException(CommonErrorCode.NOT_EXIST_BEARER_SUFFIX);
             }
-            String accessToken = bearerToken.substring(7);
+            String accessToken = bearerToken.substring(BEARER_PREFIX.length());
             JwtUtil.validateAccessToken(accessToken, secretKey);
 
             // 블랙 리스트에 어세스 토큰 추가
@@ -54,7 +54,7 @@ public class CustomLogoutHandler implements LogoutHandler {
             }
 
             // 쿠키에서 리프레시 토큰 삭제 (timeout을 0으로 두어 즉시 삭제)
-            JwtUtil.setRefreshTokenCookie(response, null, 0);
+            JwtUtil.updateRefreshTokenCookie(response, null, 0);
         } catch (RestApiException e) {
             try {
                 SendErrorResponseUtil.sendErrorResponse(response, e.getErrorCode());

--- a/src/main/java/com/ureca/ufit/global/auth/handler/CustomLogoutHandler.java
+++ b/src/main/java/com/ureca/ufit/global/auth/handler/CustomLogoutHandler.java
@@ -6,10 +6,12 @@ import static com.ureca.ufit.global.auth.util.JwtUtil.BLACKLIST_PREFIX;
 
 import com.ureca.ufit.global.auth.repository.RefreshTokenRepository;
 import com.ureca.ufit.global.auth.util.JwtUtil;
+import com.ureca.ufit.global.auth.util.SendErrorResponseUtil;
 import com.ureca.ufit.global.exception.CommonErrorCode;
 import com.ureca.ufit.global.exception.RestApiException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 import javax.crypto.SecretKey;
@@ -31,27 +33,35 @@ public class CustomLogoutHandler implements LogoutHandler {
     public void logout(HttpServletRequest request, HttpServletResponse response,
             Authentication authentication) {
 
-        // 로그아웃 시 헤더에 있는 어세스 토큰 검증
-        String bearerToken = request.getHeader(AUTH_HEADER);
-        if( bearerToken == null || !bearerToken.startsWith(BEARER_PREFIX)){
-            throw new RestApiException(CommonErrorCode.NOT_EXIST_BEARER_SUFFIX);
+        try {
+            // 로그아웃 시 헤더에 있는 어세스 토큰 검증
+            String bearerToken = request.getHeader(AUTH_HEADER);
+            if (bearerToken == null || !bearerToken.startsWith(BEARER_PREFIX)) {
+                throw new RestApiException(CommonErrorCode.NOT_EXIST_BEARER_SUFFIX);
+            }
+            String accessToken = bearerToken.substring(7);
+            JwtUtil.validateAccessToken(accessToken, secretKey);
+
+            // 블랙 리스트에 어세스 토큰 추가
+            addToBlacklistRedis(accessToken);
+
+            // 레디스에서 리프레시 토큰 삭제
+            String refreshToken = JwtUtil.getRefreshTokenCookies(request);
+            if (refreshToken != null) {
+                // Redis에서 해당 리프레시 토큰 키 삭제
+                refreshTokenRepository.findById(refreshToken)
+                        .ifPresent(refreshTokenRepository::delete);
+            }
+
+            // 쿠키에서 리프레시 토큰 삭제 (timeout을 0으로 두어 즉시 삭제)
+            JwtUtil.setRefreshTokenCookie(response, null, 0);
+        } catch (RestApiException e) {
+            try {
+                SendErrorResponseUtil.sendErrorResponse(response, e.getErrorCode());
+            } catch (IOException ex) {
+                throw new RuntimeException(ex);
+            }
         }
-        String accessToken = bearerToken.substring(7);
-        JwtUtil.validateAccessToken(accessToken, secretKey);
-
-        // 블랙 리스트에 어세스 토큰 추가
-        addToBlacklistRedis(accessToken);
-
-        // 레디스에서 리프레시 토큰 삭제
-        String refreshToken = JwtUtil.getRefreshTokenCookies(request);
-        if (refreshToken != null) {
-            // Redis에서 해당 리프레시 토큰 키 삭제
-            refreshTokenRepository.findById(refreshToken)
-                    .ifPresent(refreshTokenRepository::delete);
-        }
-
-        // 쿠키에서 리프레시 토큰 삭제 (timeout을 0으로 두어 즉시 삭제)
-        JwtUtil.setRefreshTokenCookie(response, null, 0);
     }
 
     private void addToBlacklistRedis(String accessToken) {

--- a/src/main/java/com/ureca/ufit/global/auth/handler/LoginSuccessHandler.java
+++ b/src/main/java/com/ureca/ufit/global/auth/handler/LoginSuccessHandler.java
@@ -1,0 +1,48 @@
+package com.ureca.ufit.global.auth.handler;
+
+import static com.ureca.ufit.global.auth.util.JwtUtil.AUTH_HEADER;
+import static com.ureca.ufit.global.auth.util.JwtUtil.BEARER_PREFIX;
+import static com.ureca.ufit.global.auth.util.JwtUtil.REFRESH_TOKEN_EXPIRED_MS;
+
+import com.ureca.ufit.entity.RefreshToken;
+import com.ureca.ufit.global.auth.details.CustomUserDetails;
+import com.ureca.ufit.global.auth.repository.RefreshTokenRepository;
+import com.ureca.ufit.global.auth.util.JwtUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import javax.crypto.SecretKey;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final SecretKey secretKeyKey;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+            Authentication authentication) {
+
+        // 로그인 성공 시 인증 객체의 principal을 정의하기 위한 유저 정보
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+
+        // 로그인 성공 시 어세스/리프레시 토큰 발급
+        String accessToken = JwtUtil.createAccessToken(userDetails.email(), secretKeyKey);
+        String refreshToken = JwtUtil.createRefreshToken(userDetails.email(), secretKeyKey);
+
+        // 레디스에 리프레시 토큰 저장
+        RefreshToken refreshTokenEntity = RefreshToken.of(refreshToken, userDetails.email());
+        refreshTokenRepository.save(refreshTokenEntity);
+
+        // 쿠키에 리프레시 토큰 저장 (timeout 3일)
+        JwtUtil.setRefreshTokenCookie(response, refreshToken, REFRESH_TOKEN_EXPIRED_MS /1000);
+
+        // 헤더에 어세스 토큰 저장
+        response.setHeader(AUTH_HEADER, BEARER_PREFIX + accessToken);
+    }
+
+}

--- a/src/main/java/com/ureca/ufit/global/auth/provider/LoginProvider.java
+++ b/src/main/java/com/ureca/ufit/global/auth/provider/LoginProvider.java
@@ -1,0 +1,44 @@
+package com.ureca.ufit.global.auth.provider;
+
+import com.ureca.ufit.domain.user.exception.UserErrorCode;
+import com.ureca.ufit.global.auth.service.CustomUserDetailsService;
+import com.ureca.ufit.global.exception.RestApiException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class LoginProvider implements AuthenticationProvider {
+
+    private final PasswordEncoder passwordEncoder;
+    private final CustomUserDetailsService userDetailsService;
+
+    @Override
+    public Authentication authenticate(Authentication authentication)
+            throws AuthenticationException {
+
+        String email = authentication.getName();
+
+        // 인증 객체의 principal을 정의하기 위한 유저 정보
+        UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+
+        // 비밀번호 검증
+        String password = authentication.getCredentials().toString();
+        if(!passwordEncoder.matches(password, userDetails.getPassword())){
+            throw new RestApiException(UserErrorCode.USER_PASSWORD_MISMATCH);
+        }
+
+        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return UsernamePasswordAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+}

--- a/src/main/java/com/ureca/ufit/global/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/ureca/ufit/global/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,10 @@
+package com.ureca.ufit.global.auth.repository;
+
+import com.ureca.ufit.entity.RefreshToken;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
+
+}

--- a/src/main/java/com/ureca/ufit/global/auth/service/AuthService.java
+++ b/src/main/java/com/ureca/ufit/global/auth/service/AuthService.java
@@ -1,0 +1,59 @@
+package com.ureca.ufit.global.auth.service;
+
+import static com.ureca.ufit.global.auth.util.JwtUtil.AUTH_HEADER;
+import static com.ureca.ufit.global.auth.util.JwtUtil.BEARER_PREFIX;
+import static com.ureca.ufit.global.auth.util.JwtUtil.REFRESH_TOKEN_EXPIRED_MS;
+
+import com.ureca.ufit.entity.RefreshToken;
+import com.ureca.ufit.global.auth.repository.RefreshTokenRepository;
+import com.ureca.ufit.global.auth.util.JwtUtil;
+import com.ureca.ufit.global.exception.CommonErrorCode;
+import com.ureca.ufit.global.exception.RestApiException;
+import jakarta.servlet.http.HttpServletResponse;
+import javax.crypto.SecretKey;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final SecretKey secretKey;
+
+    public void reissueToken(String bearerToken, String refreshToken, HttpServletResponse response) {
+        // 어세스 토큰 추출
+        if( bearerToken == null || !bearerToken.startsWith(BEARER_PREFIX)){
+            throw new RestApiException(CommonErrorCode.NOT_EXIST_BEARER_SUFFIX);
+        }
+        String accessToken = bearerToken.substring(7);
+
+        // 리프레시 토큰이 레디스에 있는지 확인
+        RefreshToken refreshTokenEntity = refreshTokenRepository.findById(refreshToken).orElseThrow(()->
+                new RestApiException(CommonErrorCode.REFRESH_NOT_FOUND)
+        );
+
+        // 어세스 토큰이 만료되 었는지 검증하고 이메일 추출
+        String email = JwtUtil.getEmailOnlyIfExpired(accessToken, secretKey);
+
+        // 어세스 토큰과 리프레시 토큰의 매핑 검증
+        if (!email.equals(refreshTokenEntity.getEmail())) {
+            throw new RestApiException(CommonErrorCode.REFRESH_DENIED);
+        }
+
+        // 리프레시 토큰 만료 여부 검증
+        JwtUtil.validateRefreshToken(refreshToken,secretKey);
+
+        // 리프레시 토큰 폐기 후 어세스 토큰과 리프레시 토큰 재발급 (RTR)
+        String newRefreshToken = JwtUtil.createRefreshToken(email, secretKey);
+        RefreshToken newRefreshTokenEntity = RefreshToken.of(newRefreshToken, email);
+        refreshTokenRepository.deleteById(refreshToken);
+        refreshTokenRepository.save(newRefreshTokenEntity);
+        JwtUtil.setRefreshTokenCookie(response, newRefreshToken,REFRESH_TOKEN_EXPIRED_MS/1000);
+
+        String newAccessToken = JwtUtil.createAccessToken(email, secretKey);
+        response.setHeader(AUTH_HEADER, BEARER_PREFIX + newAccessToken);
+    }
+
+}

--- a/src/main/java/com/ureca/ufit/global/auth/service/AuthService.java
+++ b/src/main/java/com/ureca/ufit/global/auth/service/AuthService.java
@@ -56,7 +56,7 @@ public class AuthService {
         RefreshToken newRefreshTokenEntity = RefreshToken.of(newRefreshToken, email);
         refreshTokenRepository.deleteById(refreshToken);
         refreshTokenRepository.save(newRefreshTokenEntity);
-        JwtUtil.setRefreshTokenCookie(response, newRefreshToken,REFRESH_TOKEN_EXPIRED_MS/1000);
+        JwtUtil.updateRefreshTokenCookie(response, newRefreshToken,REFRESH_TOKEN_EXPIRED_MS/1000);
 
         String newAccessToken = JwtUtil.createAccessToken(email, secretKey);
         response.setHeader(AUTH_HEADER, BEARER_PREFIX + newAccessToken);

--- a/src/main/java/com/ureca/ufit/global/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/com/ureca/ufit/global/auth/service/CustomUserDetailsService.java
@@ -1,0 +1,28 @@
+package com.ureca.ufit.global.auth.service;
+
+import com.ureca.ufit.domain.user.exception.UserErrorCode;
+import com.ureca.ufit.domain.user.repository.UserRepository;
+import com.ureca.ufit.entity.User;
+import com.ureca.ufit.global.auth.details.CustomUserDetails;
+import com.ureca.ufit.global.exception.RestApiException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email).orElseThrow(()->
+                new RestApiException(UserErrorCode.USER_NOT_FOUND)
+        );
+
+        return new CustomUserDetails(user.getEmail(), user.getPassword(), user.getRole());
+    }
+}

--- a/src/main/java/com/ureca/ufit/global/auth/util/JwtUtil.java
+++ b/src/main/java/com/ureca/ufit/global/auth/util/JwtUtil.java
@@ -10,10 +10,12 @@ import io.jsonwebtoken.UnsupportedJwtException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.time.Duration;
 import java.util.Date;
 import java.util.UUID;
 import javax.crypto.SecretKey;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -25,14 +27,25 @@ public class JwtUtil {
     public static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
     public static final String REFRESH_TOKEN_PREFIX = "refreshToken:";
     public static final String BLACKLIST_PREFIX = "blackList:";
+
+    public static final String JWT_CLAIM_KEY_EMAIL = "email";
+    public static final String JWT_CLAIM_KEY_TYPE = "type";
+    public static final String JWT_CLAIM_KEY_ID = "jit";
+
+    public static final String JWT_CLAIM_VALUE_ACCESS_TYPE = "access";
+    public static final String JWT_CLAIM_VALUE_REFRESH_TYPE = "refresh";
+
+    public static final String COOKIE_HEADER_NAME = "Set-Cookie";
+    public static final String COOKIE_SAME_SITE_STRATEGY = "Lax";
+
     public static final int ACCESS_TOKEN_EXPIRED_MS = 1000 * 60 * 30; // 30분
     public static final int REFRESH_TOKEN_EXPIRED_MS = 1000 * 60 * 60 * 24 * 3; // 3일
 
     public static String createToken(String email, String type, SecretKey secretKey, long expiresIn) {
         return Jwts.builder()
-                .claim("email", email)
-                .claim("type", type)
-                .claim("jit", UUID.randomUUID().toString())
+                .claim(JWT_CLAIM_KEY_EMAIL, email)
+                .claim(JWT_CLAIM_KEY_TYPE, type)
+                .claim(JWT_CLAIM_KEY_ID, UUID.randomUUID().toString())
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis() + expiresIn))
                 .signWith(secretKey)
@@ -40,19 +53,19 @@ public class JwtUtil {
     }
 
     public static String createAccessToken(String email, SecretKey secretKey) {
-        return createToken(email, "access", secretKey, ACCESS_TOKEN_EXPIRED_MS);
+        return createToken(email, JWT_CLAIM_VALUE_ACCESS_TYPE, secretKey, ACCESS_TOKEN_EXPIRED_MS);
     }
 
     public static String createRefreshToken(String email, SecretKey secretKey) {
-        return createToken(email, "refresh", secretKey, REFRESH_TOKEN_EXPIRED_MS);
+        return createToken(email, JWT_CLAIM_VALUE_REFRESH_TYPE, secretKey, REFRESH_TOKEN_EXPIRED_MS);
     }
 
     public static String getEmail(String token, SecretKey secretKey) {
-        return parseClaims(token, secretKey).get("email", String.class);
+        return parseClaims(token, secretKey).get(JWT_CLAIM_KEY_EMAIL, String.class);
     }
 
     private static String getType(String token, SecretKey secretKey) {
-        return parseClaims(token, secretKey).get("type", String.class);
+        return parseClaims(token, secretKey).get(JWT_CLAIM_KEY_TYPE, String.class);
     }
 
     public static Date getExpiration(String token, SecretKey secretKey) {
@@ -67,13 +80,12 @@ public class JwtUtil {
                 .getPayload();
     }
 
-    // 기존 메서드 대체
     public static void validateAccessToken(String token, SecretKey secretKey) {
-        validateToken(token, secretKey, "access", CommonErrorCode.EXPIRED_TOKEN);
+        validateToken(token, secretKey, JWT_CLAIM_VALUE_ACCESS_TYPE, CommonErrorCode.EXPIRED_TOKEN);
     }
 
     public static void validateRefreshToken(String token, SecretKey secretKey) {
-        validateToken(token, secretKey, "refresh", CommonErrorCode.REFRESH_DENIED);
+        validateToken(token, secretKey, JWT_CLAIM_VALUE_REFRESH_TYPE, CommonErrorCode.REFRESH_DENIED);
     }
 
     private static void validateToken(String token, SecretKey secretKey, String expectedType,
@@ -110,7 +122,7 @@ public class JwtUtil {
         } catch (RestApiException e){
             throw e;
         } catch (ExpiredJwtException e) {
-            return e.getClaims().get("email", String.class);
+            return e.getClaims().get(JWT_CLAIM_KEY_EMAIL, String.class);
         } catch (SecurityException | MalformedJwtException e) {
             throw new RestApiException(CommonErrorCode.INVALID_TOKEN);
         } catch (UnsupportedJwtException e) {
@@ -123,27 +135,32 @@ public class JwtUtil {
     }
 
 
-    public static void setRefreshTokenCookie(HttpServletResponse response, String refreshToken,
+    public static void updateRefreshTokenCookie(HttpServletResponse response, String refreshToken,
             int timeout) {
-        Cookie cookie = new Cookie(REFRESH_TOKEN_COOKIE_NAME, refreshToken);
-        cookie.setHttpOnly(true);
-        cookie.setSecure(true);
-        cookie.setPath("/");
-        cookie.setMaxAge(timeout); // 쿠키 즉시 만료
-        response.addCookie(cookie);
+        ResponseCookie cookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, refreshToken)
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .maxAge(Duration.ofSeconds(timeout))
+                .sameSite(COOKIE_SAME_SITE_STRATEGY)
+                .build();
+
+        response.setHeader(COOKIE_HEADER_NAME, cookie.toString());
     }
 
     public static String getRefreshTokenCookies(HttpServletRequest request) {
         Cookie[] cookies = request.getCookies();
+
         if (cookies == null)
-            return null;
+            throw new RestApiException(CommonErrorCode.REFRESH_DENIED);
 
         for (Cookie cookie : cookies) {
             if (REFRESH_TOKEN_COOKIE_NAME.equals(cookie.getName())) {
                 return cookie.getValue();
             }
         }
-        return null;
+
+        throw new RestApiException(CommonErrorCode.REFRESH_DENIED);
     }
 
 }

--- a/src/main/java/com/ureca/ufit/global/auth/util/SendErrorResponseUtil.java
+++ b/src/main/java/com/ureca/ufit/global/auth/util/SendErrorResponseUtil.java
@@ -1,0 +1,24 @@
+package com.ureca.ufit.global.auth.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ureca.ufit.global.exception.ErrorCode;
+import com.ureca.ufit.global.exception.ErrorResponseDto;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class SendErrorResponseUtil {
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public static void sendErrorResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException {
+        response.setStatus(errorCode.getHttpStatus().value());
+        response.setContentType("application/json;charset=UTF-8");
+        response.setCharacterEncoding("UTF-8");
+
+        ErrorResponseDto errorResponse = ErrorResponseDto.builder()
+                .code(errorCode.name())
+                .message(errorCode.getMessage())
+                .build();
+
+        objectMapper.writeValue(response.getWriter(), errorResponse);
+    }
+}

--- a/src/main/java/com/ureca/ufit/global/config/RedisConfig.java
+++ b/src/main/java/com/ureca/ufit/global/config/RedisConfig.java
@@ -7,8 +7,10 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+@EnableRedisRepositories(basePackages = "com.ureca.ufit.global.auth.repository")
 @Configuration
 public class RedisConfig {
 

--- a/src/main/java/com/ureca/ufit/global/config/SecretKeyConfig.java
+++ b/src/main/java/com/ureca/ufit/global/config/SecretKeyConfig.java
@@ -1,0 +1,21 @@
+package com.ureca.ufit.global.config;
+
+import java.util.Base64;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SecretKeyConfig {
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    @Bean
+    public SecretKey secretKey() {
+        byte[] keyBytes = Base64.getDecoder().decode(secretKey);
+        return new SecretKeySpec(keyBytes, 0, keyBytes.length, "HmacSHA256");
+    }
+}

--- a/src/main/java/com/ureca/ufit/global/config/SecurityConfig.java
+++ b/src/main/java/com/ureca/ufit/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.ureca.ufit.global.config;
 
+import com.ureca.ufit.entity.enums.Role;
 import com.ureca.ufit.global.auth.filter.ExceptionHandlerFilter;
 import com.ureca.ufit.global.auth.filter.JwtFilter;
 import com.ureca.ufit.global.auth.filter.LoginFilter;
@@ -31,9 +32,13 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-	private static final String[] AUTH_LIST = {
+	private static final String[] USER_AUTH_LIST = {
 			// 인증이 필요한 API 패턴
 			"/api/users/jwt/test"
+	};
+
+	private static final String[] ADMIN_AUTH_LIST = {
+			// 관리자 인증이 필요한 API 패턴
 	};
 
 	private final JwtFilter jwtFilter;
@@ -77,7 +82,8 @@ public class SecurityConfig {
 
 		http
 				.authorizeHttpRequests(auth -> auth
-						.requestMatchers(AUTH_LIST).authenticated()
+						.requestMatchers(USER_AUTH_LIST).authenticated()
+						.requestMatchers(ADMIN_AUTH_LIST).hasRole(Role.ADMIN.name())
 						.anyRequest().permitAll());
 
 		http

--- a/src/main/java/com/ureca/ufit/global/config/SecurityConfig.java
+++ b/src/main/java/com/ureca/ufit/global/config/SecurityConfig.java
@@ -1,14 +1,24 @@
 package com.ureca.ufit.global.config;
 
+import com.ureca.ufit.global.auth.filter.JwtFilter;
+import com.ureca.ufit.global.auth.filter.LoginFilter;
+import com.ureca.ufit.global.auth.handler.CustomLogoutHandler;
+import com.ureca.ufit.global.auth.handler.LoginSuccessHandler;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.Arrays;
 import java.util.List;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -19,32 +29,64 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+	private static final String[] AUTH_LIST = {
+			"/api/auth/login",
+	};
+
+	private final JwtFilter jwtFilter;
+	private final LoginSuccessHandler loginSuccessHandler;
+	private final AuthenticationConfiguration authenticationConfiguration;
+	private final CustomLogoutHandler customLogoutHandler;
+
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
+
+	@Bean
+	public AuthenticationManager authenticationManager() throws Exception {
+		return authenticationConfiguration.getAuthenticationManager();
+	}
+
+	@Bean
+	public LoginFilter loginFilter() throws Exception {
+		LoginFilter loginFilter = new LoginFilter();
+		loginFilter.setAuthenticationManager(authenticationManager());
+		loginFilter.setAuthenticationSuccessHandler(loginSuccessHandler);
+		return loginFilter;
+	}
+
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 		http
 			.cors(cors -> cors.configurationSource(corsConfigurationSource()))
-			.csrf((auth) -> auth.disable())
-			.formLogin((auth) -> auth.disable())
-			.httpBasic((auth) -> auth.disable())
+			// 클라이언트가 리프레시 토큰을 재발급 요청 때만 쿠키에서 사용하므로 csrf는 토큰 재발급 요청 때만 사용
+			//.csrf(csrf -> csrf.csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse()))
+			.csrf(AbstractHttpConfigurer::disable) // swagger로 api 요청 확인 때만 사용
+			.formLogin(AbstractHttpConfigurer::disable)
+			.httpBasic(AbstractHttpConfigurer::disable)
 			.sessionManagement(
 				(session) -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
 			);
 
 		http
-			.authorizeHttpRequests(
-				(auth) -> auth
-					.requestMatchers("/").permitAll()
+				.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+				.addFilterBefore(loginFilter(), JwtFilter.class)
+			.authorizeHttpRequests(auth -> auth
+				.requestMatchers(AUTH_LIST).authenticated()
+				.anyRequest().permitAll()
 			);
+
+		http
+			.logout(logoutConfig -> logoutConfig
+				.logoutUrl("/api/auth/logout")
+				.addLogoutHandler(customLogoutHandler)
+				.logoutSuccessHandler((request, response, authentication) -> {
+					response.setStatus(HttpServletResponse.SC_OK);
+				})
+		);
 
 		return http.build();
-	}
-
-	@Bean
-	public WebSecurityCustomizer webSecurityCustomizer() {
-		return web -> web.ignoring()
-			.requestMatchers(
-				"/error", "/favicon.ico", "/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html"
-			);
 	}
 
 	// Spring Security cors Bean 등록
@@ -56,6 +98,7 @@ public class SecurityConfig {
 			List.of(
 				"http://localhost:3000"
 			));
+		configuration.setExposedHeaders(List.of("Authorization"));
 		configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
 		configuration.setAllowedHeaders(List.of("*"));
 		configuration.setAllowCredentials(true);

--- a/src/main/java/com/ureca/ufit/global/exception/CommonErrorCode.java
+++ b/src/main/java/com/ureca/ufit/global/exception/CommonErrorCode.java
@@ -15,7 +15,7 @@ public enum CommonErrorCode implements ErrorCode {
 	// JWT 관련 에러코드
 	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "Invalid token"),
 	EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "Expired token"),
-	NOT_EXIST_BEARER_SUFFIX(HttpStatus.UNAUTHORIZED, "Bearer prefix is missing."),
+	NOT_EXIST_BEARER_SUFFIX(HttpStatus.BAD_REQUEST, "Bearer prefix is missing."),
 	UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "Unsupported JWT token"),
 	ILLEGAL_TOKEN(HttpStatus.UNAUTHORIZED, "Illegal JWT token"),
 	REFRESH_DENIED(HttpStatus.FORBIDDEN, "Refresh denied"),

--- a/src/main/java/com/ureca/ufit/global/exception/CommonErrorCode.java
+++ b/src/main/java/com/ureca/ufit/global/exception/CommonErrorCode.java
@@ -11,10 +11,15 @@ public enum CommonErrorCode implements ErrorCode {
 	INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "Invalid parameter included"),
 	RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "Resource not exists"),
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error"),
+
+	// JWT 관련 에러코드
 	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "Invalid token"),
 	EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "Expired token"),
 	NOT_EXIST_BEARER_SUFFIX(HttpStatus.UNAUTHORIZED, "Bearer prefix is missing."),
+	UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "Unsupported JWT token"),
+	ILLEGAL_TOKEN(HttpStatus.UNAUTHORIZED, "Illegal JWT token"),
 	REFRESH_DENIED(HttpStatus.FORBIDDEN, "Refresh denied"),
+	REFRESH_NOT_FOUND(HttpStatus.NOT_FOUND, "Refresh not found")
 	;
 
 	private final HttpStatus httpStatus;

--- a/src/test/java/com/ureca/ufit/common/fixture/UserFixture.java
+++ b/src/test/java/com/ureca/ufit/common/fixture/UserFixture.java
@@ -2,13 +2,15 @@ package com.ureca.ufit.common.fixture;
 
 import com.ureca.ufit.entity.User;
 
+import com.ureca.ufit.entity.enums.Gender;
+import com.ureca.ufit.entity.enums.Role;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class UserFixture {
 
-	public static User user() {
-		return null;
+	public static User createUser(String username, String password, int age, int famliy, Gender gender, Role role, String ratePlanId) {
+		return User.of(username, password, age, famliy, gender, role, ratePlanId);
 	}
 }

--- a/src/test/java/com/ureca/ufit/common/support/TestContainerSupport.java
+++ b/src/test/java/com/ureca/ufit/common/support/TestContainerSupport.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = PROTECTED)
 public abstract class TestContainerSupport {
 
-	private static final String POSTGRESQL_IMAGE = "postgresql:16";
+	private static final String POSTGRESQL_IMAGE = "postgres:16";
 	private static final String MONGO_IMAGE = "mongo:8.0.5";
 	private static final String REDIS_IMAGE = "redis:7.2.5";
 	private static final int POSTGRESQL_PORT = 5432;

--- a/src/test/java/com/ureca/ufit/user/controller/UserControllerTest.java
+++ b/src/test/java/com/ureca/ufit/user/controller/UserControllerTest.java
@@ -1,0 +1,288 @@
+
+package com.ureca.ufit.user.controller;
+
+import static com.ureca.ufit.global.auth.util.JwtUtil.AUTH_HEADER;
+import static com.ureca.ufit.global.auth.util.JwtUtil.BEARER_PREFIX;
+import static com.ureca.ufit.global.auth.util.JwtUtil.BLACKLIST_PREFIX;
+import static com.ureca.ufit.global.auth.util.JwtUtil.REFRESH_TOKEN_COOKIE_NAME;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.hamcrest.Matchers.startsWith;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.ureca.ufit.common.support.ApiSupport;
+import com.ureca.ufit.domain.user.controller.UserController;
+import com.ureca.ufit.domain.user.dto.request.LoginRequest;
+import com.ureca.ufit.domain.user.dto.request.RegisterRequest;
+import com.ureca.ufit.domain.user.exception.UserErrorCode;
+import com.ureca.ufit.domain.user.repository.UserRepository;
+import com.ureca.ufit.entity.enums.Gender;
+import com.ureca.ufit.entity.enums.Role;
+import com.ureca.ufit.global.auth.repository.RefreshTokenRepository;
+
+import com.ureca.ufit.global.auth.util.JwtUtil;
+import com.ureca.ufit.global.exception.CommonErrorCode;
+import jakarta.servlet.http.Cookie;
+import java.util.Objects;
+import javax.crypto.SecretKey;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.ResultActions;
+
+public class UserControllerTest extends ApiSupport {
+
+	private final String email = "test@email.com";
+	private final String password = "test123!@#";
+	private final String rateId = "1";
+
+	@Autowired
+	private RefreshTokenRepository refreshTokenRepository;
+
+	@Autowired
+	private RedisTemplate<String, String> redisTemplate;
+
+	@Autowired
+	private UserController userController;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private SecretKey secretKey;
+
+	@BeforeEach
+	void setUp() {
+		RegisterRequest registerRequest = new RegisterRequest(
+				email, password, 25, 175, Gender.MAN, Role.USER, rateId);
+
+		userController.register(registerRequest);
+	}
+
+	@AfterEach
+	void cleanUp() {
+		userRepository.deleteAll();
+		refreshTokenRepository.deleteAll();
+		redisTemplate.delete(redisTemplate.keys("*"));
+		SecurityContextHolder.clearContext();
+	}
+
+	// 로그인 관련 테스트 시작
+	@DisplayName("사용자/관리자가 로그인 하면 refreshToken 및 accessToken이 발급된다.")
+	@Test
+	void loginTest() throws Exception {
+		LoginRequest loginRequest = new LoginRequest(email, password);
+
+		ResultActions result = mockMvc.perform(post("/api/auth/login")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(toJson(loginRequest)));
+
+		result.andExpect(status().isOk())
+				.andExpect(header().exists(AUTH_HEADER))
+				.andExpect(header().string(AUTH_HEADER, startsWith(BEARER_PREFIX)))
+				.andExpect(cookie().exists(REFRESH_TOKEN_COOKIE_NAME))
+				.andExpect(cookie().httpOnly(REFRESH_TOKEN_COOKIE_NAME, true))
+				.andExpect(cookie().secure(REFRESH_TOKEN_COOKIE_NAME, true));
+	}
+
+	@DisplayName("존재하지 않는 이메일로 로그인 시도 시 404을 반환한다.")
+	@Test
+	void loginWithNonexistentEmail() throws Exception {
+		// given
+		LoginRequest request = new LoginRequest("nonexistent@email.com", "password");
+
+		// when
+		mockMvc.perform(post("/api/auth/login")
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(toJson(request))
+				)
+				//then
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.code")
+						.value(UserErrorCode.USER_NOT_FOUND.name()))
+				.andExpect(jsonPath("$.message")
+						.value(UserErrorCode.USER_NOT_FOUND.getMessage())
+				);
+	}
+
+	@DisplayName("잘못된 비밀번호로 로그인 시도 시 400을 반환한다.")
+	@Test
+	void loginWithWrongPassword() throws Exception {
+		// given
+		LoginRequest request = new LoginRequest("test@email.com", "wrongPassword");
+
+		// when
+		mockMvc.perform(post("/api/auth/login")
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(toJson(request))
+				)
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code")
+						.value(UserErrorCode.USER_PASSWORD_MISMATCH.name()))
+				.andExpect(jsonPath("$.message")
+						.value(UserErrorCode.USER_PASSWORD_MISMATCH.getMessage())
+				);
+	}
+	//-------------------------//
+
+	// 로그아웃 관련 테스트 시작
+	@DisplayName("로그인 후 로그아웃하면 refreshToken 삭제 및 accessToken 블랙리스트 처리된다.")
+	@Test
+	void logoutTest() throws Exception {
+		// 로그인
+		LoginRequest loginRequest = new LoginRequest(email, password);
+
+		var loginResult = mockMvc.perform(post("/api/auth/login")
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(toJson(loginRequest)))
+				.andExpect(status().isOk())
+				.andReturn();
+
+		String refreshToken = Objects.requireNonNull(loginResult.getResponse().getCookie(REFRESH_TOKEN_COOKIE_NAME)).getValue();
+		String bearerToken = loginResult.getResponse().getHeader(AUTH_HEADER);
+
+		// 로그아웃
+		mockMvc.perform(post("/api/auth/logout")
+						.header(AUTH_HEADER, bearerToken)
+						.cookie(new Cookie(REFRESH_TOKEN_COOKIE_NAME, refreshToken)))
+				.andExpect(status().isOk())
+				.andExpect(cookie().maxAge(REFRESH_TOKEN_COOKIE_NAME, 0));
+
+		String accessToken = Objects.requireNonNull(bearerToken).substring(7);
+		assertThat(refreshTokenRepository.findById(refreshToken)).isEmpty();
+		assertThat(redisTemplate.opsForValue().get(BLACKLIST_PREFIX + accessToken)).isEqualTo("logout");
+	}
+
+	@DisplayName("Authorization 헤더 없이 로그아웃 시도 시 401을 반환한다.")
+	@Test
+	void logoutWithoutAuthorizationHeader() throws Exception {
+		mockMvc.perform(post("/api/auth/logout"))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code").value(CommonErrorCode.NOT_EXIST_BEARER_SUFFIX.name()))
+				.andExpect(jsonPath("$.message").value(CommonErrorCode.NOT_EXIST_BEARER_SUFFIX.getMessage()));
+	}
+
+	@DisplayName("유효하지 않은 accessToken으로 로그아웃하면 401 반환")
+	@Test
+	void logoutWithInvalidAccessToken() throws Exception {
+		mockMvc.perform(post("/api/auth/logout")
+						.header(AUTH_HEADER, "Bearer invalid.token.here")
+						.cookie(new Cookie(REFRESH_TOKEN_COOKIE_NAME, "dummy")))
+				.andExpect(status().isUnauthorized())
+				.andExpect(jsonPath("$.code").value(CommonErrorCode.INVALID_TOKEN.name()))
+				.andExpect(jsonPath("$.message").value(CommonErrorCode.INVALID_TOKEN.getMessage()));
+	}
+	//-------------------------//
+
+	// 토큰 재발급 관련 테스트 시작
+	@DisplayName("accessToken이 만료되지 않으면 재발급 요청 시 예외가 발생한다.")
+	@Test
+	void reissueFailsIfAccessTokenIsStillValid() throws Exception {
+		// 로그인으로 유효한 accessToken, refreshToken 발급
+		LoginRequest loginRequest = new LoginRequest(email, password);
+
+		var loginResult = mockMvc.perform(post("/api/auth/login")
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(toJson(loginRequest)))
+				.andExpect(status().isOk())
+				.andReturn();
+
+		String validAccessToken = loginResult.getResponse().getHeader(AUTH_HEADER);
+		String validRefreshToken = loginResult.getResponse().getCookie(REFRESH_TOKEN_COOKIE_NAME).getValue();
+
+		// accessToken이 아직 유효한 상태로 재발급 시도
+		mockMvc.perform(post("/api/auth/reissue/token")
+						.header(AUTH_HEADER, validAccessToken)
+						.cookie(new Cookie(REFRESH_TOKEN_COOKIE_NAME, validRefreshToken)))
+				.andExpect(status().isForbidden())
+				.andExpect(jsonPath("$.code").value(CommonErrorCode.REFRESH_DENIED.name()))
+				.andExpect(jsonPath("$.message").value(CommonErrorCode.REFRESH_DENIED.getMessage()));
+	}
+
+	@DisplayName("Authorization 헤더가 없으면 400을 반환한다")
+	@Test
+	void reissueFailsWithoutAuthorizationHeader() throws Exception {
+		mockMvc.perform(post("/api/auth/reissue/token")
+						.cookie(new Cookie(REFRESH_TOKEN_COOKIE_NAME, "dummy")))
+				.andExpect(status().isBadRequest());
+	}
+
+
+	@DisplayName("accessToken이 만료되었을 경우 refreshToken을 통해 재발급할 수 있다.")
+	@Test
+	void reissueSucceedsWhenAccessTokenIsExpired() throws Exception {
+		// 1. 회원가입 → 로그인하여 토큰 발급
+		LoginRequest loginRequest = new LoginRequest(email, password);
+
+		var loginResult = mockMvc.perform(post("/api/auth/login")
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(toJson(loginRequest)))
+				.andExpect(status().isOk())
+				.andReturn();
+
+		String refreshToken = loginResult.getResponse().getCookie(REFRESH_TOKEN_COOKIE_NAME).getValue();
+		String expiredAccessToken = JwtUtil.createToken(email, "access", secretKey, 1);
+
+		// 3. 재발급 요청
+		var reissueResult = mockMvc.perform(post("/api/auth/reissue/token")
+						.header(AUTH_HEADER, BEARER_PREFIX + expiredAccessToken)
+						.cookie(new Cookie(REFRESH_TOKEN_COOKIE_NAME, refreshToken)))
+				.andExpect(status().isOk())
+				.andExpect(header().exists(AUTH_HEADER))
+				.andExpect(header().string(AUTH_HEADER, startsWith(BEARER_PREFIX)))
+				.andExpect(cookie().exists(REFRESH_TOKEN_COOKIE_NAME))
+				.andReturn();
+
+		// 4. 응답 토큰 확인
+		String newAccessToken = reissueResult.getResponse().getHeader(AUTH_HEADER);
+		String newRefreshToken = Objects.requireNonNull(
+                reissueResult.getResponse().getCookie(REFRESH_TOKEN_COOKIE_NAME)).getValue();
+
+		assertThat(newAccessToken).isNotEqualTo(expiredAccessToken);
+		assertThat(newRefreshToken).isNotEqualTo(refreshToken);
+	}
+
+	@DisplayName("Redis에 존재하지 않는 refreshToken으로 재발급 시 404 반환")
+	@Test
+	void reissueWithTamperedRefreshToken() throws Exception {
+		String expiredAccessToken = JwtUtil.createToken(email, "access", secretKey, 1);
+		String tamperedRefreshToken = "nonexistent-refresh-token";
+
+		mockMvc.perform(post("/api/auth/reissue/token")
+						.header(AUTH_HEADER, BEARER_PREFIX + expiredAccessToken)
+						.cookie(new Cookie(REFRESH_TOKEN_COOKIE_NAME, tamperedRefreshToken)))
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.code").value(CommonErrorCode.REFRESH_NOT_FOUND.name()))
+				.andExpect(jsonPath("$.message").value(CommonErrorCode.REFRESH_NOT_FOUND.getMessage()));
+	}
+
+	@DisplayName("블랙리스트에 등록된 accessToken으로 재발급 시도 시 401 반환")
+	@Test
+	void reissueWithBlacklistedAccessToken() throws Exception {
+		// 1. 로그인
+		LoginRequest loginRequest = new LoginRequest(email, password);
+		var loginResult = mockMvc.perform(post("/api/auth/login")
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(toJson(loginRequest)))
+				.andReturn();
+
+		String accessToken = loginResult.getResponse().getHeader(AUTH_HEADER).substring(7);
+		String refreshToken = loginResult.getResponse().getCookie(REFRESH_TOKEN_COOKIE_NAME).getValue();
+
+		// 2. 블랙리스트에 등록
+		redisTemplate.opsForValue().set(BLACKLIST_PREFIX + accessToken, "logout");
+
+		// 3. 재발급 시도
+		mockMvc.perform(post("/api/auth/reissue/token")
+						.header(AUTH_HEADER, BEARER_PREFIX + accessToken)
+						.cookie(new Cookie(REFRESH_TOKEN_COOKIE_NAME, refreshToken)))
+				.andExpect(status().isUnauthorized())
+				.andExpect(jsonPath("$.code").value(CommonErrorCode.INVALID_TOKEN.name()));
+	}
+
+}

--- a/src/test/java/com/ureca/ufit/user/filter/JwtFilterTest.java
+++ b/src/test/java/com/ureca/ufit/user/filter/JwtFilterTest.java
@@ -1,0 +1,110 @@
+package com.ureca.ufit.user.filter;
+
+import com.ureca.ufit.global.auth.filter.JwtFilter;
+import com.ureca.ufit.global.auth.service.CustomUserDetailsService;
+import com.ureca.ufit.global.auth.util.JwtUtil;
+import com.ureca.ufit.global.exception.CommonErrorCode;
+import com.ureca.ufit.global.exception.RestApiException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import javax.crypto.SecretKey;
+import java.io.IOException;
+import java.util.Collections;
+
+import static com.ureca.ufit.global.auth.util.JwtUtil.AUTH_HEADER;
+import static com.ureca.ufit.global.auth.util.JwtUtil.BEARER_PREFIX;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+class JwtFilterTest {
+
+    private JwtFilter jwtFilter;
+    private RedisTemplate<String, String> redisTemplate;
+    private CustomUserDetailsService userDetailsService;
+    private SecretKey secretKey;
+
+    @BeforeEach
+    void setUp() {
+        redisTemplate = mock(RedisTemplate.class);
+        userDetailsService = mock(CustomUserDetailsService.class);
+        secretKey = mock(SecretKey.class);
+
+        jwtFilter = new JwtFilter(userDetailsService, redisTemplate, secretKey);
+    }
+
+    @DisplayName("화이트리스트 URI는 필터링 하지 않는다")
+    @Test
+    void whiteListFilteringTest() throws ServletException, IOException {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/swagger-ui/index.html");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain filterChain = mock(FilterChain.class);
+
+        // when
+        jwtFilter.doFilter(request, response, filterChain);
+
+        // then
+        verify(filterChain, times(1)).doFilter(request, response);
+    }
+
+    @DisplayName("유효한 토큰이 존재하면 인증객체를 설정한다")
+    @Test
+    void validTokenTest() throws Exception {
+        // given
+        String email = "user@example.com";
+        String validToken = "valid.token.value";
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/protected");
+        request.addHeader(AUTH_HEADER, BEARER_PREFIX + validToken);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain filterChain = mock(FilterChain.class);
+
+        UserDetails mockUser = new User(email, "", Collections.emptyList());
+
+        when(redisTemplate.hasKey("blacklist:" + validToken)).thenReturn(false);
+        when(userDetailsService.loadUserByUsername(email)).thenReturn(mockUser);
+
+        // static mock
+        try (MockedStatic<JwtUtil> mockedJwtUtil = mockStatic(JwtUtil.class)) {
+            mockedJwtUtil
+                    .when(() -> JwtUtil.validateAccessToken(validToken, secretKey))
+                    .thenCallRealMethod(); // 또는 .doNothing() 불가, void는 따로 처리 ↓
+
+            // 실제로는 아무 일도 하지 않도록 설정
+            mockedJwtUtil.when(() -> JwtUtil.validateAccessToken(validToken, secretKey)).thenAnswer(inv -> null);
+
+            mockedJwtUtil.when(() -> JwtUtil.getEmail(validToken, secretKey)).thenReturn(email);
+
+            // when
+            jwtFilter.doFilter(request, response, filterChain);
+
+            // then
+            verify(userDetailsService).loadUserByUsername(email);
+            verify(filterChain).doFilter(request, response);
+        }
+    }
+
+    @DisplayName("토큰이 없고 Public이 아니면 예외가 발생한다.")
+    @Test
+    void isNotPublicTest() {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/protected");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain filterChain = mock(FilterChain.class);
+
+        // then
+        assertThatThrownBy(() -> jwtFilter.doFilter(request, response, filterChain))
+                .isInstanceOf(RestApiException.class)
+                .hasMessageContaining(CommonErrorCode.NOT_EXIST_BEARER_SUFFIX.getMessage());
+    }
+}

--- a/src/test/java/com/ureca/ufit/user/filter/LoginFilterTest.java
+++ b/src/test/java/com/ureca/ufit/user/filter/LoginFilterTest.java
@@ -1,0 +1,61 @@
+package com.ureca.ufit.user.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ureca.ufit.domain.user.dto.request.LoginRequest;
+import com.ureca.ufit.global.auth.filter.LoginFilter;
+import jakarta.servlet.ServletException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class LoginFilterTest {
+
+    private LoginFilter loginFilter;
+    private AuthenticationManager authenticationManager;
+
+    @BeforeEach
+    void setUp() {
+        authenticationManager = mock(AuthenticationManager.class);
+        loginFilter = new LoginFilter();
+        loginFilter.setAuthenticationManager(authenticationManager);
+    }
+
+    @DisplayName("로그인 요청을 정상적으로 파싱하고 인증을 위임한다")
+    @Test
+    void loginFilterTest() throws IOException, ServletException {
+        // given
+        LoginRequest loginRequest = new LoginRequest("test@example.com", "password123");
+        ObjectMapper objectMapper = new ObjectMapper();
+        byte[] requestBody = objectMapper.writeValueAsBytes(loginRequest);
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setMethod("POST");
+        request.setRequestURI("/api/auth/login");
+        request.setContentType("application/json");
+        request.setContent(requestBody);
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        Authentication dummyAuth = mock(Authentication.class);
+        when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
+                .thenReturn(dummyAuth);
+
+        // when
+        Authentication result = loginFilter.attemptAuthentication(request, response);
+
+        // then
+        assertThat(result).isNotNull();
+        verify(authenticationManager, times(1)).authenticate(any(UsernamePasswordAuthenticationToken.class));
+    }
+}

--- a/src/test/java/com/ureca/ufit/user/provider/LoginProviderTest.java
+++ b/src/test/java/com/ureca/ufit/user/provider/LoginProviderTest.java
@@ -13,15 +13,17 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class LoginProviderTest {
+
+    private final String EMAIL = "test@email.com";
+    private final String RAW_PASSWORD = "password123";
+    private final String ENCODED_PASSWORD = "encoded_password";
 
     @Mock
     PasswordEncoder passwordEncoder;
@@ -36,20 +38,18 @@ class LoginProviderTest {
     @Test
     void authenticateSuccess() {
         // given
-        String email = "test@email.com";
-        String rawPassword = "password123";
-        String encodedPassword = "encoded_password";
 
-        UserDetails userDetails = User.withUsername(email)
-                .password(encodedPassword)
+
+        UserDetails userDetails = User.withUsername(EMAIL)
+                .password(ENCODED_PASSWORD)
                 .roles("USER")
                 .build();
 
         UsernamePasswordAuthenticationToken token =
-                new UsernamePasswordAuthenticationToken(email, rawPassword);
+                new UsernamePasswordAuthenticationToken(EMAIL, RAW_PASSWORD);
 
-        when(userDetailsService.loadUserByUsername(email)).thenReturn(userDetails);
-        when(passwordEncoder.matches(rawPassword, encodedPassword)).thenReturn(true);
+        when(userDetailsService.loadUserByUsername(EMAIL)).thenReturn(userDetails);
+        when(passwordEncoder.matches(RAW_PASSWORD, ENCODED_PASSWORD)).thenReturn(true);
 
         // when
         Authentication result = loginProvider.authenticate(token);

--- a/src/test/java/com/ureca/ufit/user/provider/LoginProviderTest.java
+++ b/src/test/java/com/ureca/ufit/user/provider/LoginProviderTest.java
@@ -1,0 +1,62 @@
+package com.ureca.ufit.user.provider;
+
+import com.ureca.ufit.domain.user.exception.UserErrorCode;
+import com.ureca.ufit.global.auth.provider.LoginProvider;
+import com.ureca.ufit.global.auth.service.CustomUserDetailsService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LoginProviderTest {
+
+    @Mock
+    PasswordEncoder passwordEncoder;
+
+    @Mock
+    CustomUserDetailsService userDetailsService;
+
+    @InjectMocks
+    LoginProvider loginProvider;
+
+    @DisplayName("정상 로그인 시 Authentication 객체를 반환한다.")
+    @Test
+    void authenticateSuccess() {
+        // given
+        String email = "test@email.com";
+        String rawPassword = "password123";
+        String encodedPassword = "encoded_password";
+
+        UserDetails userDetails = User.withUsername(email)
+                .password(encodedPassword)
+                .roles("USER")
+                .build();
+
+        UsernamePasswordAuthenticationToken token =
+                new UsernamePasswordAuthenticationToken(email, rawPassword);
+
+        when(userDetailsService.loadUserByUsername(email)).thenReturn(userDetails);
+        when(passwordEncoder.matches(rawPassword, encodedPassword)).thenReturn(true);
+
+        // when
+        Authentication result = loginProvider.authenticate(token);
+
+        // then
+        assertThat(result.isAuthenticated()).isTrue();
+        assertThat(result.getPrincipal()).isEqualTo(userDetails);
+    }
+
+}

--- a/src/test/java/com/ureca/ufit/user/service/AuthServiceTest.java
+++ b/src/test/java/com/ureca/ufit/user/service/AuthServiceTest.java
@@ -65,7 +65,7 @@ class AuthServiceTest {
             mocked.when(() -> JwtUtil.validateRefreshToken(refreshToken, secretKey)).thenAnswer(inv -> null);
             mocked.when(() -> JwtUtil.createRefreshToken(email, secretKey)).thenReturn(newRefreshToken);
             mocked.when(() -> JwtUtil.createAccessToken(email, secretKey)).thenReturn(newAccessToken);
-            mocked.when(() -> JwtUtil.setRefreshTokenCookie(response, newRefreshToken, REFRESH_TOKEN_EXPIRED_MS / 1000)).thenCallRealMethod();
+            mocked.when(() -> JwtUtil.updateRefreshTokenCookie(response, newRefreshToken, REFRESH_TOKEN_EXPIRED_MS / 1000)).thenCallRealMethod();
 
             // when
             authService.reissueToken(bearerToken, refreshToken, response);

--- a/src/test/java/com/ureca/ufit/user/service/AuthServiceTest.java
+++ b/src/test/java/com/ureca/ufit/user/service/AuthServiceTest.java
@@ -1,0 +1,82 @@
+package com.ureca.ufit.user.service;
+
+import static com.ureca.ufit.global.auth.util.JwtUtil.AUTH_HEADER;
+import static com.ureca.ufit.global.auth.util.JwtUtil.BEARER_PREFIX;
+import static com.ureca.ufit.global.auth.util.JwtUtil.BLACKLIST_PREFIX;
+import static com.ureca.ufit.global.auth.util.JwtUtil.REFRESH_TOKEN_EXPIRED_MS;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.ureca.ufit.entity.RefreshToken;
+import com.ureca.ufit.global.auth.repository.RefreshTokenRepository;
+import com.ureca.ufit.global.auth.service.AuthService;
+import com.ureca.ufit.global.auth.util.JwtUtil;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Optional;
+import javax.crypto.SecretKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Mock
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Mock
+    private SecretKey secretKey;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @InjectMocks
+    private AuthService authService;
+
+    @DisplayName("토큰 재발급시 어세스토큰과 리프레시토큰이 모두 재발급 된다.(RTR)")
+    @Test
+    void reissueTokenSuccess() {
+        // given
+        String email = "user@example.com";
+        String accessToken = "access.token.value";
+        String bearerToken = BEARER_PREFIX + accessToken;
+        String refreshToken = "refresh.token.value";
+        String newRefreshToken = "new.refresh.token";
+        String newAccessToken = "new.access.token";
+
+        RefreshToken refreshTokenEntity = RefreshToken.of(refreshToken, email);
+
+        when(redisTemplate.hasKey(BLACKLIST_PREFIX + accessToken)).thenReturn(false);
+        when(refreshTokenRepository.findById(refreshToken)).thenReturn(Optional.of(refreshTokenEntity));
+
+        try (MockedStatic<JwtUtil> mocked = mockStatic(JwtUtil.class)) {
+            mocked.when(() -> JwtUtil.getEmailOnlyIfExpired(accessToken, secretKey)).thenReturn(email);
+            mocked.when(() -> JwtUtil.validateRefreshToken(refreshToken, secretKey)).thenAnswer(inv -> null);
+            mocked.when(() -> JwtUtil.createRefreshToken(email, secretKey)).thenReturn(newRefreshToken);
+            mocked.when(() -> JwtUtil.createAccessToken(email, secretKey)).thenReturn(newAccessToken);
+            mocked.when(() -> JwtUtil.setRefreshTokenCookie(response, newRefreshToken, REFRESH_TOKEN_EXPIRED_MS / 1000)).thenCallRealMethod();
+
+            // when
+            authService.reissueToken(bearerToken, refreshToken, response);
+
+            // then
+            verify(refreshTokenRepository).deleteById(refreshToken);
+            ArgumentCaptor<RefreshToken> captor = ArgumentCaptor.forClass(RefreshToken.class);
+            verify(refreshTokenRepository).save(captor.capture());
+            RefreshToken saved = captor.getValue();
+            assertThat(saved.getEmail()).isEqualTo(email);
+            verify(response).setHeader(AUTH_HEADER, BEARER_PREFIX + newAccessToken);
+        }
+    }
+}

--- a/src/test/java/com/ureca/ufit/user/service/UserServiceTest.java
+++ b/src/test/java/com/ureca/ufit/user/service/UserServiceTest.java
@@ -1,14 +1,25 @@
 package com.ureca.ufit.user.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.ureca.ufit.common.fixture.UserFixture;
+import com.ureca.ufit.domain.user.dto.request.RegisterRequest;
+import com.ureca.ufit.domain.user.dto.response.RegisterResponse;
+import com.ureca.ufit.entity.User;
+import com.ureca.ufit.entity.enums.Gender;
+import com.ureca.ufit.entity.enums.Role;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.ureca.ufit.domain.user.repository.UserRepository;
 import com.ureca.ufit.domain.user.service.UserService;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @ExtendWith(MockitoExtension.class)
 public class UserServiceTest {
@@ -16,17 +27,37 @@ public class UserServiceTest {
 	@Mock
 	UserRepository userRepository;
 
+	@Mock
+	PasswordEncoder passwordEncoder;
+
 	@InjectMocks
 	UserService userService;
 
-	@DisplayName("")
+
+	@DisplayName("사용자/관리자는 정상적으로 회원가입할 수 있다.")
 	@Test
-	void test() {
+	void registerTest() {
 		// given
+		RegisterRequest request = new RegisterRequest(
+				"test@email.com", "test123!@#",
+				28, 175,
+				Gender.MAN, Role.USER, "1"
+		);
+
+		String encodedPassword = "encoded_password";
+		when(passwordEncoder.encode(request.password())).thenReturn(encodedPassword);
+
+		User savedUser = UserFixture.createUser(
+				request.email(), encodedPassword,
+				request.age(), request.family(),
+				request.gender(), request.role(), request.ratePlanId()
+		);
+		when(userRepository.save(Mockito.any(User.class))).thenReturn(savedUser);
 
 		// when
+		RegisterResponse response = userService.register(request);
 
 		// then
-
+		assertThat(response.success()).isTrue();
 	}
 }


### PR DESCRIPTION
## 🔥 Related Issue

- Close #1

## 📑 Task

- CORS 설정
- 사용자 인증 필터(LoginFilter) 등록
- JWT 인증 필터(JwtFilter) 등록
- 로그인 성공 시 토큰 발급 및 응답 처리
- RefreshToken 사용 API에 CSRF 보호 적용
- 역할에 따른 리다이렉트 처리 (USER, ADMIN)
- 로그인 실패 시 예외 및 리다이렉트 처리
- 로그아웃 시 AccessToken 블랙리스트 등록
- Token 재발급
- RefreshToken 삭제 및 쿠키 제거

## 🔍 To Reviewer

- RefreshToken 재발급 로직
- refreshToken 키 값을 refreshToken자체로 해도되는 지
- 로그아웃 헨들러