### PR TITLE
Fix: 어드민 요금제 목록 조회 API Cursor 변경

### DIFF
--- a/src/main/java/com/ureca/ufit/domain/admin/service/AdminService.java
+++ b/src/main/java/com/ureca/ufit/domain/admin/service/AdminService.java
@@ -3,7 +3,7 @@ package com.ureca.ufit.domain.admin.service;
 import org.springframework.stereotype.Service;
 
 import com.ureca.ufit.domain.admin.dto.response.AdminRatePlanResponse;
-import com.ureca.ufit.domain.rateplan.repository.RatePlanQueryRepository;
+import com.ureca.ufit.domain.rateplan.repository.RatePlanRepository;
 import com.ureca.ufit.global.dto.CursorPageResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -12,9 +12,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class AdminService {
 
-	private final RatePlanQueryRepository ratePlanQueryRepository;
+	private final RatePlanRepository ratePlanRepository;
 
 	public CursorPageResponse<AdminRatePlanResponse> getRatePlansByCursor(String cursor, int size, String type) {
-		return ratePlanQueryRepository.getRatePlansByCursor(cursor, size, type);
+		return ratePlanRepository.getRatePlansByCursor(cursor, size, type);
 	}
 }

--- a/src/main/java/com/ureca/ufit/domain/rateplan/repository/RatePlanQueryRepository.java
+++ b/src/main/java/com/ureca/ufit/domain/rateplan/repository/RatePlanQueryRepository.java
@@ -1,0 +1,9 @@
+package com.ureca.ufit.domain.rateplan.repository;
+
+import com.ureca.ufit.domain.admin.dto.response.AdminRatePlanResponse;
+import com.ureca.ufit.global.dto.CursorPageResponse;
+
+public interface RatePlanQueryRepository {
+
+	public CursorPageResponse<AdminRatePlanResponse> getRatePlansByCursor(String cursor, int size, String type);
+}

--- a/src/main/java/com/ureca/ufit/domain/rateplan/repository/RatePlanQueryRepositoryImpl.java
+++ b/src/main/java/com/ureca/ufit/domain/rateplan/repository/RatePlanQueryRepositoryImpl.java
@@ -9,16 +9,16 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.aggregation.AggregationOperation;
 import org.springframework.data.mongodb.core.query.Criteria;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Repository;
 
 import com.ureca.ufit.domain.admin.dto.response.AdminRatePlanResponse;
 import com.ureca.ufit.global.dto.CursorPageResponse;
 
 import lombok.RequiredArgsConstructor;
 
-@Component
+@Repository
 @RequiredArgsConstructor
-public class RatePlanQueryRepository {
+public class RatePlanQueryRepositoryImpl implements RatePlanQueryRepository {
 
 	private static final String IS_DELETED = "is_deleted";
 	private static final String CURSOR = "_id";

--- a/src/main/java/com/ureca/ufit/domain/rateplan/repository/RatePlanRepository.java
+++ b/src/main/java/com/ureca/ufit/domain/rateplan/repository/RatePlanRepository.java
@@ -1,0 +1,10 @@
+package com.ureca.ufit.domain.rateplan.repository;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import com.ureca.ufit.entity.RatePlan;
+
+@Repository
+public interface RatePlanRepository extends MongoRepository<RatePlan, String>, RatePlanQueryRepository {
+}

--- a/src/test/java/com/ureca/ufit/common/config/TestMongoAuditingConfig.java
+++ b/src/test/java/com/ureca/ufit/common/config/TestMongoAuditingConfig.java
@@ -1,0 +1,10 @@
+package com.ureca.ufit.common.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
+
+@TestConfiguration
+@EnableMongoAuditing
+public class TestMongoAuditingConfig {
+
+}

--- a/src/test/java/com/ureca/ufit/common/support/DataMongoSupport.java
+++ b/src/test/java/com/ureca/ufit/common/support/DataMongoSupport.java
@@ -1,0 +1,16 @@
+package com.ureca.ufit.common.support;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+import com.ureca.ufit.common.config.TestMongoAuditingConfig;
+
+@DataMongoTest
+@Import(TestMongoAuditingConfig.class)
+public abstract class DataMongoSupport extends TestContainerSupport {
+
+	@Autowired
+	protected MongoTemplate mongoTemplate;
+}

--- a/src/test/java/com/ureca/ufit/rateplan/repository/RatePlanQueryRepositoryTest.java
+++ b/src/test/java/com/ureca/ufit/rateplan/repository/RatePlanQueryRepositoryTest.java
@@ -12,22 +12,16 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.mongodb.core.MongoTemplate;
 
-import com.ureca.ufit.common.support.TestContainerSupport;
+import com.ureca.ufit.common.support.DataMongoSupport;
 import com.ureca.ufit.domain.admin.dto.response.AdminRatePlanResponse;
-import com.ureca.ufit.domain.rateplan.repository.RatePlanQueryRepository;
+import com.ureca.ufit.domain.rateplan.repository.RatePlanQueryRepositoryImpl;
 import com.ureca.ufit.global.dto.CursorPageResponse;
 
-@SpringBootTest
-class RatePlanQueryRepositoryTest extends TestContainerSupport {
+class RatePlanQueryRepositoryTest extends DataMongoSupport {
 
 	@Autowired
-	RatePlanQueryRepository ratePlanQueryRepository;
-
-	@Autowired
-	MongoTemplate mongoTemplate;
+	RatePlanQueryRepositoryImpl ratePlanQueryRepositoryImpl;
 
 	@DisplayName("커서 기반으로 요금제 목록을 조회한다")
 	@Test
@@ -61,7 +55,8 @@ class RatePlanQueryRepositoryTest extends TestContainerSupport {
 		mongoTemplate.getDb().getCollection("rate_plans").insertMany(docs);
 
 		// when
-		CursorPageResponse<AdminRatePlanResponse> response = ratePlanQueryRepository.getRatePlansByCursor(null, SIZE,
+		CursorPageResponse<AdminRatePlanResponse> response = ratePlanQueryRepositoryImpl.getRatePlansByCursor(null,
+			SIZE,
 			TYPE);
 
 		// then

--- a/src/test/java/com/ureca/ufit/rateplan/repository/RatePlanQueryRepositoryTest.java
+++ b/src/test/java/com/ureca/ufit/rateplan/repository/RatePlanQueryRepositoryTest.java
@@ -3,7 +3,6 @@ package com.ureca.ufit.rateplan.repository;
 import static org.assertj.core.api.Assertions.*;
 
 import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -39,7 +38,6 @@ class RatePlanQueryRepositoryTest extends TestContainerSupport {
 		final int SIZE = 3;
 		final String TYPE = "date";
 		final String PLAN = "Plan ";
-		final String CREATED_AT = "createdAt";
 
 		List<Document> docs = new ArrayList<>();
 		for (int i = START_INDEX; i <= END_INDEX; i++) {
@@ -56,7 +54,7 @@ class RatePlanQueryRepositoryTest extends TestContainerSupport {
 				.append("discount_benefit", Map.of("benefit", "discount"))
 				.append("is_enabled", true)
 				.append("is_deleted", false)
-				.append(CREATED_AT, LocalDateTime.now().minusDays(10 - i))
+				.append("createdAt", LocalDateTime.now().minusDays(10 - i))
 				.append("updatedAt", LocalDateTime.now().minusDays(10 - i))
 			);
 		}
@@ -71,13 +69,7 @@ class RatePlanQueryRepositoryTest extends TestContainerSupport {
 			() -> assertThat(response.item().size()).isEqualTo(SIZE),
 			() -> assertThat(response.item().get(0).planName()).isEqualTo(PLAN + END_INDEX),
 			() -> assertThat(response.hasNext()).isTrue(),
-			() -> {
-				LocalDateTime docLocal = (LocalDateTime)docs.get(END_INDEX - SIZE - 1).get(CREATED_AT);
-				String expectedCursor = docLocal
-					.truncatedTo(ChronoUnit.MILLIS)
-					.toString();
-				assertThat(response.nextCursor()).isEqualTo(expectedCursor);
-			}
+			() -> assertThat(response.nextCursor()).isEqualTo(docs.get(END_INDEX - SIZE).get("_id").toString())
 		);
 
 	}


### PR DESCRIPTION
## 🔥 Related Issue

- Close #19 


## 📑 Task

- 어드민 요금제 목록 조회 API Cursor 변경(`createdAt` -> `Id`)
- RatePlan MongoRepository 추상화
- DataMongoSupport 추가


## 🔍 To Reviewer

- 집중적으로 리뷰해야될 부분 있으면 작성
