### PR TITLE
Feat: 채팅방 생성 및 아이디 조회 API

### DIFF
--- a/src/main/java/com/ureca/ufit/domain/chatbot/controller/ChaBotController.java
+++ b/src/main/java/com/ureca/ufit/domain/chatbot/controller/ChaBotController.java
@@ -3,14 +3,18 @@ package com.ureca.ufit.domain.chatbot.controller;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.ureca.ufit.domain.chatbot.dto.response.ChatMessageDto;
+import com.ureca.ufit.domain.chatbot.dto.response.ChatRoomCreateResponse;
 import com.ureca.ufit.domain.chatbot.service.ChatBotMessageService;
+import com.ureca.ufit.domain.chatbot.service.ChatRoomService;
 import com.ureca.ufit.global.dto.CursorPageResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -21,6 +25,7 @@ import lombok.RequiredArgsConstructor;
 public class ChaBotController {
 
 	private final ChatBotMessageService chatBotMessageService;
+	private final ChatRoomService chatRoomService;
 
 	@GetMapping("/{chatroomId}")
 	public ResponseEntity<CursorPageResponse<ChatMessageDto>> getMessages(
@@ -30,6 +35,12 @@ public class ChaBotController {
 
 		CursorPageResponse<ChatMessageDto> response = chatBotMessageService.getChatMessages(chatRoomId, pageable,
 			lastMessageId);
+		return ResponseEntity.ok(response);
+	}
+
+	@PostMapping("/rooms")
+	public ResponseEntity<ChatRoomCreateResponse> getOrCreateChatRoom(@AuthenticationPrincipal String email){
+		ChatRoomCreateResponse response = chatRoomService.getOrCreateChatRoom(email);
 		return ResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/com/ureca/ufit/domain/chatbot/dto/ChatRoomMapper.java
+++ b/src/main/java/com/ureca/ufit/domain/chatbot/dto/ChatRoomMapper.java
@@ -1,0 +1,15 @@
+package com.ureca.ufit.domain.chatbot.dto;
+
+import com.ureca.ufit.domain.chatbot.dto.response.ChatRoomCreateResponse;
+import com.ureca.ufit.entity.ChatRoom;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ChatRoomMapper {
+
+	public static ChatRoomCreateResponse toChatroomCreateResponse(ChatRoom chatRoom) {
+		return new ChatRoomCreateResponse(chatRoom.getId());
+	}
+}

--- a/src/main/java/com/ureca/ufit/domain/chatbot/dto/ChatRoomMapper.java
+++ b/src/main/java/com/ureca/ufit/domain/chatbot/dto/ChatRoomMapper.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 public class ChatRoomMapper {
 
 	public static ChatRoomCreateResponse toChatroomCreateResponse(ChatRoom chatRoom) {
-		return new ChatRoomCreateResponse(chatRoom.getId());
+		boolean isAnonymous = (chatRoom.getUser() == null);
+		return new ChatRoomCreateResponse(chatRoom.getId(), isAnonymous);
 	}
 }

--- a/src/main/java/com/ureca/ufit/domain/chatbot/dto/response/ChatRoomCreateResponse.java
+++ b/src/main/java/com/ureca/ufit/domain/chatbot/dto/response/ChatRoomCreateResponse.java
@@ -1,6 +1,7 @@
 package com.ureca.ufit.domain.chatbot.dto.response;
 
 public record ChatRoomCreateResponse(
-	Long chatRoomId
+	Long chatRoomId,
+	boolean isAnonymous
 ) {
 }

--- a/src/main/java/com/ureca/ufit/domain/chatbot/dto/response/ChatRoomCreateResponse.java
+++ b/src/main/java/com/ureca/ufit/domain/chatbot/dto/response/ChatRoomCreateResponse.java
@@ -1,0 +1,6 @@
+package com.ureca.ufit.domain.chatbot.dto.response;
+
+public record ChatRoomCreateResponse(
+	Long chatRoomId
+) {
+}

--- a/src/main/java/com/ureca/ufit/domain/chatbot/repository/ChatBotMessageRepositoryImpl.java
+++ b/src/main/java/com/ureca/ufit/domain/chatbot/repository/ChatBotMessageRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.ureca.ufit.domain.chatbot.repository;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.bson.types.ObjectId;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -35,7 +36,7 @@ public class ChatBotMessageRepositoryImpl implements ChatBotMessageRepositoryCus
 
 		Criteria criteria = Criteria.where(FIELD_CHAT_ROOM_ID).is(chatRoom.getId());
 		if (lastMessageId != null && !lastMessageId.isBlank()) {
-			criteria = criteria.and(FIELD_ID).lt(lastMessageId);
+			criteria = criteria.and(FIELD_ID).lt(new ObjectId(lastMessageId));
 		}
 		MatchOperation match = Aggregation.match(criteria);
 		pipeline.add(match);

--- a/src/main/java/com/ureca/ufit/domain/chatbot/repository/ChatRoomRepository.java
+++ b/src/main/java/com/ureca/ufit/domain/chatbot/repository/ChatRoomRepository.java
@@ -1,14 +1,19 @@
 package com.ureca.ufit.domain.chatbot.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import com.ureca.ufit.domain.chatbot.exception.ChatBotErrorCode;
 import com.ureca.ufit.entity.ChatRoom;
+import com.ureca.ufit.entity.User;
 import com.ureca.ufit.global.exception.RestApiException;
 
 @Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+
+	Optional<ChatRoom> findByUser(User user);
 
 	default ChatRoom getById(Long id) {
 		return findById(id).orElseThrow(() -> new RestApiException(ChatBotErrorCode.CHATROOM_NOT_FOUND));

--- a/src/main/java/com/ureca/ufit/domain/chatbot/service/ChatRoomService.java
+++ b/src/main/java/com/ureca/ufit/domain/chatbot/service/ChatRoomService.java
@@ -16,13 +16,19 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ChatRoomService {
 
+	private static final String ANONYMOUS_USER = "anonymousUser";
+
 	private final ChatRoomRepository chatRoomRepository;
 	private final UserRepository userRepository;
 
 	@Transactional
 	public ChatRoomCreateResponse getOrCreateChatRoom(String email) {
-		User findUser = userRepository.getByEmail(email);
+		if (ANONYMOUS_USER.equals(email)) {
+			ChatRoom newChatRoom = chatRoomRepository.save(ChatRoom.of(null));
+			return ChatRoomMapper.toChatroomCreateResponse(newChatRoom);
+		}
 
+		User findUser = userRepository.getByEmail(email);
 		return chatRoomRepository.findByUser(findUser)
 			.map(ChatRoomMapper::toChatroomCreateResponse)
 			.orElseGet(() -> {

--- a/src/main/java/com/ureca/ufit/domain/chatbot/service/ChatRoomService.java
+++ b/src/main/java/com/ureca/ufit/domain/chatbot/service/ChatRoomService.java
@@ -1,0 +1,33 @@
+package com.ureca.ufit.domain.chatbot.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ureca.ufit.domain.chatbot.dto.ChatRoomMapper;
+import com.ureca.ufit.domain.chatbot.dto.response.ChatRoomCreateResponse;
+import com.ureca.ufit.domain.chatbot.repository.ChatRoomRepository;
+import com.ureca.ufit.domain.user.repository.UserRepository;
+import com.ureca.ufit.entity.ChatRoom;
+import com.ureca.ufit.entity.User;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ChatRoomService {
+
+	private final ChatRoomRepository chatRoomRepository;
+	private final UserRepository userRepository;
+
+	@Transactional
+	public ChatRoomCreateResponse getOrCreateChatRoom(String email) {
+		User findUser = userRepository.getByEmail(email);
+
+		return chatRoomRepository.findByUser(findUser)
+			.map(ChatRoomMapper::toChatroomCreateResponse)
+			.orElseGet(() -> {
+				ChatRoom savedChatRoom = chatRoomRepository.save(ChatRoom.of(findUser));
+				return ChatRoomMapper.toChatroomCreateResponse(savedChatRoom);
+			});
+	}
+}

--- a/src/main/java/com/ureca/ufit/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/ureca/ufit/domain/user/repository/UserRepository.java
@@ -1,11 +1,19 @@
 package com.ureca.ufit.domain.user.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import com.ureca.ufit.domain.user.exception.UserErrorCode;
 import com.ureca.ufit.entity.User;
+import com.ureca.ufit.global.exception.RestApiException;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+	Optional<User> findByEmail(String email);
 
+	default User getByEmail(String email) {
+		return findByEmail(email).orElseThrow(() -> new RestApiException(UserErrorCode.USER_NOT_FOUND));
+	}
 }

--- a/src/main/java/com/ureca/ufit/entity/ChatRoom.java
+++ b/src/main/java/com/ureca/ufit/entity/ChatRoom.java
@@ -25,7 +25,7 @@ public class ChatRoom {
 	@GeneratedValue(strategy = IDENTITY)
 	private Long id;
 
-	@OneToOne(fetch = LAZY, optional = false)
+	@OneToOne(fetch = LAZY, optional = true)
 	@JoinColumn(name = "user_id", referencedColumnName = "user_id")
 	private User user;
 

--- a/src/main/java/com/ureca/ufit/entity/User.java
+++ b/src/main/java/com/ureca/ufit/entity/User.java
@@ -75,4 +75,18 @@ public class User extends TimeBaseEntity {
 		this.role = role;
 		this.ratePlanId = ratePlanId;
 	}
+
+	public static User of(String email, String password, int age, int family, Gender gender, Role role,
+		String ratePlanId) {
+
+		return User.builder()
+			.email(email)
+			.password(password)
+			.age(age)
+			.family(family)
+			.gender(gender)
+			.role(role)
+			.ratePlanId(ratePlanId)
+			.build();
+	}
 }

--- a/src/main/java/com/ureca/ufit/global/auth/filter/JwtFilter.java
+++ b/src/main/java/com/ureca/ufit/global/auth/filter/JwtFilter.java
@@ -44,7 +44,8 @@ public class JwtFilter extends OncePerRequestFilter {
             "/api/chats/message",
             "/api/chats/messages/ai",
             "/api/chats/review",
-            "/api/chats"
+            "/api/chats",
+            "/api/chats/rooms"
     );
 
     private static final AntPathMatcher matcher = new AntPathMatcher();

--- a/src/test/java/com/ureca/ufit/chatbot/repository/ChatBotMessageRepositoryTest.java
+++ b/src/test/java/com/ureca/ufit/chatbot/repository/ChatBotMessageRepositoryTest.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.bson.Document;
+import org.bson.types.ObjectId;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,7 +40,7 @@ public class ChatBotMessageRepositoryTest extends DataMongoSupport {
 		List<Document> docs = new ArrayList<>();
 		for (int i = START_INDEX; i <= END_INDEX; i++) {
 			docs.add(new Document()
-				.append("_id", "room1-msg-" + i)
+				.append("_id", new ObjectId())
 				.append("chat_room_id", CHAT_ROOM_ID)
 				.append("content", i)
 				.append("owner", i % 2 == 0)
@@ -86,7 +87,7 @@ public class ChatBotMessageRepositoryTest extends DataMongoSupport {
 		List<Document> docs = new ArrayList<>();
 		for (int i = 1; i <= 5; i++) {
 			docs.add(new Document()
-				.append("_id", "room2-msg-" + i)
+				.append("_id", new ObjectId())
 				.append("chat_room_id", CHAT_ROOM_ID)
 				.append("content", i)
 				.append("owner", i % 2 == 0)

--- a/src/test/java/com/ureca/ufit/chatbot/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/ureca/ufit/chatbot/service/ChatRoomServiceTest.java
@@ -34,7 +34,7 @@ public class ChatRoomServiceTest {
 	private ChatRoomService chatRoomService;
 
 	@Test
-	@DisplayName("기존 채팅방이 있을 때 기존 채팅방을 반환한다")
+	@DisplayName("회원에 대해 기존 채팅방이 있을 때 기존 채팅방을 반환한다")
 	public void getExistingChatRoom() {
 		// given
 		String email = "test@email.com";
@@ -51,11 +51,12 @@ public class ChatRoomServiceTest {
 
 		// then
 		assertThat(result.chatRoomId()).isEqualTo(chatRoomId);
+		assertThat(result.isAnonymous()).isFalse();
 		then(chatRoomRepository).should(never()).save(any(ChatRoom.class));
 	}
 
 	@Test
-	@DisplayName("기존 채팅방이 없을 때 새로운 채팅방을 생성하여 반환한다")
+	@DisplayName("회원에 대해 기존 채팅방이 없을 때 새로운 채팅방을 생성하여 반환한다")
 	public void getOrCreateChatRoom_NoChatRoom_CreatesAndReturnsNewChatRoom() {
 		// given
 		String email = "test@email.com";
@@ -73,6 +74,26 @@ public class ChatRoomServiceTest {
 
 		// then
 		assertThat(result.chatRoomId()).isEqualTo(chatRoomId);
+		assertThat(result.isAnonymous()).isFalse();
+		then(chatRoomRepository).should().save(any(ChatRoom.class));
+	}
+
+	@Test
+	@DisplayName("비회원 사용자인 경우 새 채팅방을 생성하고 isAnonymous가 true인 응답을 반환한다")
+	public void getOrCreateChatRoom_AnonymousUser() {
+		// given
+		String email = "anonymousUser";
+		Long chatRoomId = 3L;
+
+		ChatRoom anonymousChatRoom = ChatRoomFixture.chatRoom(chatRoomId, null);
+		given(chatRoomRepository.save(any(ChatRoom.class))).willReturn(anonymousChatRoom);
+
+		// when
+		ChatRoomCreateResponse result = chatRoomService.getOrCreateChatRoom(email);
+
+		// then
+		assertThat(result.chatRoomId()).isEqualTo(chatRoomId);
+		assertThat(result.isAnonymous()).isTrue();
 		then(chatRoomRepository).should().save(any(ChatRoom.class));
 	}
 }

--- a/src/test/java/com/ureca/ufit/chatbot/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/ureca/ufit/chatbot/service/ChatRoomServiceTest.java
@@ -1,0 +1,78 @@
+package com.ureca.ufit.chatbot.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.ureca.ufit.common.fixture.ChatRoomFixture;
+import com.ureca.ufit.common.fixture.UserFixture;
+import com.ureca.ufit.domain.chatbot.dto.response.ChatRoomCreateResponse;
+import com.ureca.ufit.domain.chatbot.repository.ChatRoomRepository;
+import com.ureca.ufit.domain.chatbot.service.ChatRoomService;
+import com.ureca.ufit.domain.user.repository.UserRepository;
+import com.ureca.ufit.entity.ChatRoom;
+import com.ureca.ufit.entity.User;
+
+@ExtendWith(MockitoExtension.class)
+public class ChatRoomServiceTest {
+
+	@Mock
+	private ChatRoomRepository chatRoomRepository;
+
+	@Mock
+	private UserRepository userRepository;
+
+	@InjectMocks
+	private ChatRoomService chatRoomService;
+
+	@Test
+	@DisplayName("기존 채팅방이 있을 때 기존 채팅방을 반환한다")
+	public void getExistingChatRoom() {
+		// given
+		String email = "test@email.com";
+		Long chatRoomId = 1L;
+
+		User user = UserFixture.user(email);
+		ChatRoom existingChatRoom = ChatRoomFixture.chatRoom(chatRoomId, user);
+
+		given(userRepository.getByEmail(email)).willReturn(user);
+		given(chatRoomRepository.findByUser(user)).willReturn(Optional.of(existingChatRoom));
+
+		// when
+		ChatRoomCreateResponse result = chatRoomService.getOrCreateChatRoom(email);
+
+		// then
+		assertThat(result.chatRoomId()).isEqualTo(chatRoomId);
+		then(chatRoomRepository).should(never()).save(any(ChatRoom.class));
+	}
+
+	@Test
+	@DisplayName("기존 채팅방이 없을 때 새로운 채팅방을 생성하여 반환한다")
+	public void getOrCreateChatRoom_NoChatRoom_CreatesAndReturnsNewChatRoom() {
+		// given
+		String email = "test@email.com";
+		Long chatRoomId = 2L;
+
+		User user = UserFixture.user(email);
+		ChatRoom newChatRoom = ChatRoomFixture.chatRoom(chatRoomId, user);
+
+		given(userRepository.getByEmail(email)).willReturn(user);
+		given(chatRoomRepository.findByUser(user)).willReturn(Optional.empty());
+		given(chatRoomRepository.save(any(ChatRoom.class))).willReturn(newChatRoom);
+
+		// when
+		ChatRoomCreateResponse result = chatRoomService.getOrCreateChatRoom(email);
+
+		// then
+		assertThat(result.chatRoomId()).isEqualTo(chatRoomId);
+		then(chatRoomRepository).should().save(any(ChatRoom.class));
+	}
+}

--- a/src/test/java/com/ureca/ufit/common/fixture/UserFixture.java
+++ b/src/test/java/com/ureca/ufit/common/fixture/UserFixture.java
@@ -1,6 +1,8 @@
 package com.ureca.ufit.common.fixture;
 
 import com.ureca.ufit.entity.User;
+import com.ureca.ufit.entity.enums.Gender;
+import com.ureca.ufit.entity.enums.Role;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -8,7 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class UserFixture {
 
-	public static User user() {
-		return null;
+	public static User user(String email) {
+		return User.of(email, "password", 10, 0, Gender.MAN, Role.USER, "aPlan");
 	}
 }


### PR DESCRIPTION
## 🔥 Related Issue

- Close #31 


## 📑 Task

- 채팅방 생성 및 아이디 조회 API 구현
  - 회원: 유저 이메일을 통해 채팅방 조회
    - 기존 채팅방 존재 시, 이 아이디를 반환 
    - 없으면 새로 생성 후 아이디 반환
  - 비회원: 새로 채팅방 생성 후 아이디 반환
  - 응답값에 생성된 채팅방 id와 비회원 여부를 포함
- Service 테스트 작성
- User 엔티티 정적 생성자(of) 추가
- 채팅방 메시지 조회 관련해서 커서 String -> ObjectId 비교로 수정

## 🔍 To Reviewer

- Repository 테스트는 작성할 부분이 없고, 추후에 Controller 테스트 작성 예정입니다.
