### PR TITLE
Test: 어드민 요금제 목록 API 단위 테스트

### DIFF
--- a/src/main/java/com/ureca/ufit/entity/RatePlan.java
+++ b/src/main/java/com/ureca/ufit/entity/RatePlan.java
@@ -89,4 +89,20 @@ public class RatePlan extends MongoTimeBaseEntity {
 		this.isDeleted = isDeleted;
 	}
 
+	public static RatePlan of(String planName, String summary, int monthlyFee, int discountFee,
+		String dataAllowance, String voiceAllowance, String smsAllowance,
+		Map<String, Object> basicBenefit, boolean isEnabled, boolean isDeleted) {
+		return RatePlan.builder()
+			.planName(planName)
+			.summary(summary)
+			.monthlyFee(monthlyFee)
+			.discountFee(discountFee)
+			.dataAllowance(dataAllowance)
+			.voiceAllowance(voiceAllowance)
+			.smsAllowance(smsAllowance)
+			.basicBenefit(basicBenefit)
+			.isEnabled(isEnabled)
+			.isDeleted(isDeleted)
+			.build();
+	}
 }

--- a/src/test/java/com/ureca/ufit/common/fixture/RatePlanFixture.java
+++ b/src/test/java/com/ureca/ufit/common/fixture/RatePlanFixture.java
@@ -1,0 +1,28 @@
+package com.ureca.ufit.common.fixture;
+
+import static lombok.AccessLevel.*;
+
+import java.util.Map;
+
+import com.ureca.ufit.entity.RatePlan;
+
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = PRIVATE)
+public class RatePlanFixture {
+
+	public static RatePlan ratePlan(String planName, int monthlyFee) {
+		return RatePlan.of(
+			planName,
+			"요금제",
+			monthlyFee,
+			1000,
+			"100G",
+			"무제한",
+			"무제한",
+			Map.of("benefit", "basic"),
+			true,
+			true
+		);
+	}
+}

--- a/src/test/java/com/ureca/ufit/rateplan/repository/RatePlanQueryRepositoryTest.java
+++ b/src/test/java/com/ureca/ufit/rateplan/repository/RatePlanQueryRepositoryTest.java
@@ -1,21 +1,21 @@
 package com.ureca.ufit.rateplan.repository;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
-import org.bson.Document;
-import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import com.ureca.ufit.common.fixture.RatePlanFixture;
 import com.ureca.ufit.common.support.DataMongoSupport;
 import com.ureca.ufit.domain.admin.dto.response.AdminRatePlanResponse;
 import com.ureca.ufit.domain.rateplan.repository.RatePlanQueryRepositoryImpl;
+import com.ureca.ufit.domain.rateplan.repository.RatePlanRepository;
+import com.ureca.ufit.entity.RatePlan;
 import com.ureca.ufit.global.dto.CursorPageResponse;
 
 class RatePlanQueryRepositoryTest extends DataMongoSupport {
@@ -23,49 +23,102 @@ class RatePlanQueryRepositoryTest extends DataMongoSupport {
 	@Autowired
 	RatePlanQueryRepositoryImpl ratePlanQueryRepositoryImpl;
 
+	@Autowired
+	RatePlanRepository ratePlanRepository;
+
+	@AfterEach
+	void tearDown() {
+		ratePlanRepository.deleteAll();
+	}
+
 	@DisplayName("커서 기반으로 요금제 목록을 조회한다")
 	@Test
 	void getRatePlansByCursor() {
 		// given
-		final int START_INDEX = 1;
-		final int END_INDEX = 10;
-		final int SIZE = 3;
-		final String TYPE = "date";
-		final String PLAN = "Plan ";
+		final int SIZE = 2;
+		final String TYPE = "lowestPrice";
 
-		List<Document> docs = new ArrayList<>();
-		for (int i = START_INDEX; i <= END_INDEX; i++) {
-			docs.add(new Document()
-				.append("plan_name", PLAN + i)
-				.append("summary", "Summary " + i)
-				.append("monthly_fee", i * 1000)
-				.append("discount_fee", i * 100)
-				.append("data_allowance", "10GB")
-				.append("voice_allowance", "100min")
-				.append("sms_allowance", "100")
-				.append("basic_benefit", Map.of("benefit", "basic"))
-				.append("special_benefit", Map.of("benefit", "special"))
-				.append("discount_benefit", Map.of("benefit", "discount"))
-				.append("is_enabled", true)
-				.append("is_deleted", false)
-				.append("createdAt", LocalDateTime.now().minusDays(10 - i))
-				.append("updatedAt", LocalDateTime.now().minusDays(10 - i))
-			);
-		}
-		mongoTemplate.getDb().getCollection("rate_plans").insertMany(docs);
+		RatePlan plan1 = RatePlanFixture.ratePlan("plan1", 100);
+		RatePlan plan2 = RatePlanFixture.ratePlan("plan2", 500);
+		RatePlan plan3 = RatePlanFixture.ratePlan("plan3", 900);
+		RatePlan plan4 = RatePlanFixture.ratePlan("plan4", 700);
+		RatePlan plan5 = RatePlanFixture.ratePlan("plan5", 300);
+		List<RatePlan> ratePlans = ratePlanRepository.saveAll(List.of(plan1, plan2, plan3, plan4, plan5));
 
-		// when
-		CursorPageResponse<AdminRatePlanResponse> response = ratePlanQueryRepositoryImpl.getRatePlansByCursor(null,
+		CursorPageResponse<AdminRatePlanResponse> response1 = ratePlanQueryRepositoryImpl.getRatePlansByCursor(
+			null,
 			SIZE,
-			TYPE);
-
-		// then
-		Assertions.assertAll(
-			() -> assertThat(response.item().size()).isEqualTo(SIZE),
-			() -> assertThat(response.item().get(0).planName()).isEqualTo(PLAN + END_INDEX),
-			() -> assertThat(response.hasNext()).isTrue(),
-			() -> assertThat(response.nextCursor()).isEqualTo(docs.get(END_INDEX - SIZE).get("_id").toString())
+			TYPE
 		);
 
+		// when
+		CursorPageResponse<AdminRatePlanResponse> response2 = ratePlanQueryRepositoryImpl.getRatePlansByCursor(
+			response1.nextCursor(),
+			SIZE,
+			TYPE
+		);
+
+		// then
+		assertAll(
+			() -> assertThat(response2.item().size()).isEqualTo(SIZE),
+			() -> assertThat(response2.item().get(SIZE - 1).planName()).isEqualTo(plan4.getPlanName()),
+			() -> assertThat(response2.nextCursor()).isEqualTo(plan4.getMonthlyFee() + "/" + plan4.getId())
+		);
+	}
+
+	@DisplayName("낮은 가격 순으로 요금제 목록을 조회한다.")
+	@Test
+	void getRatePlansOrderByLowestPrice() {
+		// given
+		final int SIZE = 2;
+		final String TYPE = "lowestPrice";
+
+		RatePlan plan1 = RatePlanFixture.ratePlan("plan1", 100);
+		RatePlan plan2 = RatePlanFixture.ratePlan("plan2", 500);
+		RatePlan plan3 = RatePlanFixture.ratePlan("plan3", 900);
+		RatePlan plan4 = RatePlanFixture.ratePlan("plan4", 700);
+		RatePlan plan5 = RatePlanFixture.ratePlan("plan5", 300);
+		ratePlanRepository.saveAll(List.of(plan1, plan2, plan3, plan4, plan5));
+
+		// when
+		CursorPageResponse<AdminRatePlanResponse> response = ratePlanQueryRepositoryImpl.getRatePlansByCursor(
+			null,
+			SIZE,
+			TYPE
+		);
+
+		// then
+		assertAll(
+			() -> assertThat(response.item().size()).isEqualTo(SIZE),
+			() -> assertThat(response.item().get(SIZE - 1).planName()).isEqualTo(plan5.getPlanName())
+		);
+	}
+
+	@DisplayName("높은 가격 순으로 요금제 목록을 조회한다.")
+	@Test
+	void getRatePlansOrderByHighestPrice() {
+		// given
+		final int SIZE = 2;
+		final String TYPE = "highestPrice";
+
+		RatePlan plan1 = RatePlanFixture.ratePlan("plan1", 100);
+		RatePlan plan2 = RatePlanFixture.ratePlan("plan2", 500);
+		RatePlan plan3 = RatePlanFixture.ratePlan("plan3", 900);
+		RatePlan plan4 = RatePlanFixture.ratePlan("plan4", 700);
+		RatePlan plan5 = RatePlanFixture.ratePlan("plan5", 300);
+		ratePlanRepository.saveAll(List.of(plan1, plan2, plan3, plan4, plan5));
+
+		// when
+		CursorPageResponse<AdminRatePlanResponse> response = ratePlanQueryRepositoryImpl.getRatePlansByCursor(
+			null,
+			SIZE,
+			TYPE
+		);
+
+		// then
+		assertAll(
+			() -> assertThat(response.item().size()).isEqualTo(SIZE),
+			() -> assertThat(response.item().get(SIZE - 1).planName()).isEqualTo(plan4.getPlanName())
+		);
 	}
 }

--- a/src/test/java/com/ureca/ufit/rateplan/repository/RatePlanQueryRepositoryTest.java
+++ b/src/test/java/com/ureca/ufit/rateplan/repository/RatePlanQueryRepositoryTest.java
@@ -121,4 +121,26 @@ class RatePlanQueryRepositoryTest extends DataMongoSupport {
 			() -> assertThat(response.item().get(SIZE - 1).planName()).isEqualTo(plan4.getPlanName())
 		);
 	}
+
+	@DisplayName("요금제 목록이 비어있을 때 빈 목록이 조회된다.")
+	@Test
+	void getEmptyWhenRatePlanIsEmpty() {
+		// given
+		final int SIZE = 10;
+		final String TYPE = "highestPrice";
+
+		// when
+		CursorPageResponse<AdminRatePlanResponse> response = ratePlanQueryRepositoryImpl.getRatePlansByCursor(
+			null,
+			SIZE,
+			TYPE
+		);
+
+		// then
+		assertAll(
+			() -> assertThat(response.item().size()).isZero(),
+			() -> assertThat(response.hasNext()).isFalse(),
+			() -> assertThat(response.nextCursor()).isNull()
+		);
+	}
 }


### PR DESCRIPTION
## 🔥 Related Issue

- Close #29 


## 📑 Task

- 어드민 요금제 목록 API Filter 값에 따른 Cursor 변경
  - 최신순(기본): rateplan_id
  - 가격순(내림차순/오름차순): rateplan_monthlyfee + "/" + rateplan_id
- RatePlan Fixture 생성
- 어드민 요금제 목록 API 단위 테스트 추가
  - cursor를 이용한 다음 목록 조회 단위 테스트
  -  낮은 요금제 목록 조회 단위 테스트
  - 높은 요금제 목록 조회 단위 테스트


## 🔍 To Reviewer

- 집중적으로 리뷰해야될 부분 있으면 작성
