### PR TITLE
feat: 챗봇 대화 기록 생성 API

### DIFF
--- a/src/main/java/com/ureca/ufit/domain/chatbot/controller/ChaBotController.java
+++ b/src/main/java/com/ureca/ufit/domain/chatbot/controller/ChaBotController.java
@@ -13,9 +13,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.ureca.ufit.domain.chatbot.dto.request.CreateChatBotMessageRequest;
 import com.ureca.ufit.domain.chatbot.dto.request.CreateChatBotReviewRequest;
 import com.ureca.ufit.domain.chatbot.dto.response.ChatMessageDto;
 import com.ureca.ufit.domain.chatbot.dto.response.ChatRoomCreateResponse;
+import com.ureca.ufit.domain.chatbot.dto.response.CreateChatBotMessageResponse;
 import com.ureca.ufit.domain.chatbot.dto.response.CreateChatBotReviewResponse;
 import com.ureca.ufit.domain.chatbot.service.ChatBotMessageService;
 import com.ureca.ufit.domain.chatbot.service.ChatBotReviewService;
@@ -55,6 +57,14 @@ public class ChaBotController {
 	public ResponseEntity<CreateChatBotReviewResponse> createChatBotReview(
 		@RequestBody @Valid CreateChatBotReviewRequest request) {
 		CreateChatBotReviewResponse response = chatBotReviewService.createChatBotReview(request);
+		return ResponseEntity.status(HttpStatus.CREATED).body(response);
+	}
+
+	@PostMapping("/message")
+	public ResponseEntity<CreateChatBotMessageResponse> createChatBotMessage(
+		@AuthenticationPrincipal Long userId,
+		@RequestBody @Valid CreateChatBotMessageRequest request) {
+		CreateChatBotMessageResponse response = chatBotMessageService.createChatBotMessage(request, userId);
 		return ResponseEntity.status(HttpStatus.CREATED).body(response);
 	}
 

--- a/src/main/java/com/ureca/ufit/domain/chatbot/dto/ChatMessageMapper.java
+++ b/src/main/java/com/ureca/ufit/domain/chatbot/dto/ChatMessageMapper.java
@@ -1,0 +1,15 @@
+package com.ureca.ufit.domain.chatbot.dto;
+
+import com.ureca.ufit.domain.chatbot.dto.request.CreateAIAnswerRequest;
+import com.ureca.ufit.domain.chatbot.dto.request.CreateChatBotMessageRequest;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ChatMessageMapper {
+	public static CreateAIAnswerRequest toCreateAIAnswerRequest(CreateChatBotMessageRequest request, Long userId) {
+		return new CreateAIAnswerRequest(userId, request.content(), request.chatRoomId());
+	}
+
+}

--- a/src/main/java/com/ureca/ufit/domain/chatbot/dto/request/CreateAIAnswerRequest.java
+++ b/src/main/java/com/ureca/ufit/domain/chatbot/dto/request/CreateAIAnswerRequest.java
@@ -1,0 +1,18 @@
+package com.ureca.ufit.domain.chatbot.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record CreateAIAnswerRequest(
+
+	@Positive
+	Long userId,
+
+	@NotNull
+	String content,
+
+	@NotNull
+	@Positive
+	Long chatRoomId
+) {
+}

--- a/src/main/java/com/ureca/ufit/domain/chatbot/dto/request/CreateChatBotMessageRequest.java
+++ b/src/main/java/com/ureca/ufit/domain/chatbot/dto/request/CreateChatBotMessageRequest.java
@@ -1,0 +1,18 @@
+package com.ureca.ufit.domain.chatbot.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+public record CreateChatBotMessageRequest(
+
+	@NotNull
+	@Size(min = 1, max = 300)
+	String content,
+
+	@NotNull
+	@Positive
+	Long chatRoomId
+
+) {
+}

--- a/src/main/java/com/ureca/ufit/domain/chatbot/dto/request/CreateChatBotReviewRequest.java
+++ b/src/main/java/com/ureca/ufit/domain/chatbot/dto/request/CreateChatBotReviewRequest.java
@@ -13,9 +13,12 @@ public record CreateChatBotReviewRequest(
 	@Positive
 	@Max(5)
 	Integer rating,
+
 	String content,
+
 	@NotEmpty
 	Map<String, Object> recommendPlans,
+
 	@NotNull
 	@Positive
 	Long chatRoomId

--- a/src/main/java/com/ureca/ufit/domain/chatbot/dto/response/CreateChatBotMessageResponse.java
+++ b/src/main/java/com/ureca/ufit/domain/chatbot/dto/response/CreateChatBotMessageResponse.java
@@ -1,0 +1,27 @@
+package com.ureca.ufit.domain.chatbot.dto.response;
+
+import java.util.Map;
+
+import com.ureca.ufit.entity.enums.AnswerType;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record CreateChatBotMessageResponse(
+
+	@NotNull
+	@Positive
+	Long messageId,
+
+	@Positive
+	Long userId,
+
+	@NotNull
+	String answer,
+
+	@NotNull
+	AnswerType answerType,
+
+	Map<String, Map<String, Object>> recommendPlans
+) {
+}

--- a/src/main/java/com/ureca/ufit/domain/chatbot/exception/ChatBotErrorCode.java
+++ b/src/main/java/com/ureca/ufit/domain/chatbot/exception/ChatBotErrorCode.java
@@ -12,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 public enum ChatBotErrorCode implements ErrorCode {
 
 	CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅방을 찾을 수 없습니다."),
+	LLM_TIMEOUT(HttpStatus.GATEWAY_TIMEOUT, "챗봇 답변 생성 시 오류가 발생하였습니다."),
+	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 UserId의 User를 찾을 수 없습니다."),
 	;
 
 	private final HttpStatus httpStatus;

--- a/src/main/java/com/ureca/ufit/domain/chatbot/service/ChatBotMessageService.java
+++ b/src/main/java/com/ureca/ufit/domain/chatbot/service/ChatBotMessageService.java
@@ -2,12 +2,19 @@ package com.ureca.ufit.domain.chatbot.service;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
 
+import com.ureca.ufit.domain.chatbot.dto.ChatMessageMapper;
+import com.ureca.ufit.domain.chatbot.dto.request.CreateAIAnswerRequest;
+import com.ureca.ufit.domain.chatbot.dto.request.CreateChatBotMessageRequest;
 import com.ureca.ufit.domain.chatbot.dto.response.ChatMessageDto;
+import com.ureca.ufit.domain.chatbot.dto.response.CreateChatBotMessageResponse;
+import com.ureca.ufit.domain.chatbot.exception.ChatBotErrorCode;
 import com.ureca.ufit.domain.chatbot.repository.ChatBotMessageRepository;
 import com.ureca.ufit.domain.chatbot.repository.ChatRoomRepository;
 import com.ureca.ufit.entity.ChatRoom;
 import com.ureca.ufit.global.dto.CursorPageResponse;
+import com.ureca.ufit.global.exception.RestApiException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -17,11 +24,31 @@ public class ChatBotMessageService {
 
 	private final ChatBotMessageRepository chatBotMessageRepository;
 	private final ChatRoomRepository chatRoomRepository;
+	private final RestTemplate restTemplate;
+	private final String fastApiUrl = "https://ai.u-fit.site/api/chats/message/ai";
 
 	public CursorPageResponse<ChatMessageDto> getChatMessages(Long chatRoomId, Pageable pageable,
 		String lastMessageId) {
 		ChatRoom findChatRoom = chatRoomRepository.getById(chatRoomId);
 
 		return chatBotMessageRepository.findMessagesPage(findChatRoom, pageable, lastMessageId);
+	}
+
+	public CreateChatBotMessageResponse createChatBotMessage(CreateChatBotMessageRequest request, Long userId) {
+
+		// Todo : content에 대한 금칙어 판단 필요
+
+		CreateAIAnswerRequest createAIAnswerRequest = ChatMessageMapper.toCreateAIAnswerRequest(request, userId);
+
+		try {
+			return restTemplate.postForObject(
+				fastApiUrl,
+				createAIAnswerRequest,
+				CreateChatBotMessageResponse.class
+			);
+
+		} catch (Exception e) {
+			throw new RestApiException(ChatBotErrorCode.LLM_TIMEOUT);
+		}
 	}
 }

--- a/src/main/java/com/ureca/ufit/entity/ChatBotMessage.java
+++ b/src/main/java/com/ureca/ufit/entity/ChatBotMessage.java
@@ -47,4 +47,15 @@ public class ChatBotMessage extends MongoTimeBaseEntity {
 		this.bPlanId = bPlanId;
 		this.chatRoomId = chatRoomId;
 	}
+
+	public static ChatBotMessage of(String content, boolean owner, Long aPlanId, Long bPlanId, Long chatRoomId) {
+		return ChatBotMessage.builder()
+			.content(content)
+			.owner(owner)
+			.aPlanId(aPlanId)
+			.bPlanId(bPlanId)
+			.chatRoomId(chatRoomId)
+			.build();
+	}
+
 }

--- a/src/main/java/com/ureca/ufit/entity/enums/AnswerType.java
+++ b/src/main/java/com/ureca/ufit/entity/enums/AnswerType.java
@@ -1,0 +1,14 @@
+package com.ureca.ufit.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AnswerType {
+
+	RECOMMEND("요금제추천"),
+	GENERAL("일반답변");
+
+	private final String answerType;
+}


### PR DESCRIPTION
## 🔥 Related Issue

- Close #41 


## 📑 Task

- 챗봇 대화 기록 생성 API  (/api/chats/message) 작성
-  createChatBotMessage : FastAPI로 요청 보내도록 하였습니다

## 🔍 To Reviewer

- 아래 내용 리뷰 시 참고 부탁드립니다.
- 챗봇 메시지 저장 (유저 메시지) 은 책임 분리 원칙에 의거하여 fastapi쪽에서 진행하는 것으로 변경하였습니다. 

### 💦현재 미완성된 부분
- 금칙어 필터링 및 관련 예외처리 
- 단위 테스트, 통합 테스트 (전체 로직이 완성되면 작성 예정) 
