### PR TITLE
[fix] 채팅방 비회원 처리 조건 수정

### DIFF
--- a/src/main/java/com/ureca/ufit/domain/chatbot/controller/ChaBotController.java
+++ b/src/main/java/com/ureca/ufit/domain/chatbot/controller/ChaBotController.java
@@ -37,7 +37,7 @@ public class ChaBotController implements ChaBotControllerApiSpec {
 
 	@Override
 	public ResponseEntity<ChatRoomCreateResponse> getOrCreateChatRoom(CustomUserDetails userDetails) {
-		ChatRoomCreateResponse response = chatRoomService.getOrCreateChatRoom(userDetails.email());
+		ChatRoomCreateResponse response = chatRoomService.getOrCreateChatRoom(userDetails);
 		return ResponseEntity.ok(response);
 	}
 
@@ -50,7 +50,8 @@ public class ChaBotController implements ChaBotControllerApiSpec {
 	@Override
 	public ResponseEntity<CreateChatBotMessageResponse> createChatBotMessage(CustomUserDetails userDetails,
 		CreateChatBotMessageRequest request) {
-		CreateChatBotMessageResponse response = chatBotMessageService.createChatBotMessage(request, userDetails.userId());
+		CreateChatBotMessageResponse response = chatBotMessageService.createChatBotMessage(request,
+			userDetails.userId());
 		return ResponseEntity.status(HttpStatus.CREATED).body(response);
 	}
 

--- a/src/main/java/com/ureca/ufit/domain/chatbot/service/ChatRoomService.java
+++ b/src/main/java/com/ureca/ufit/domain/chatbot/service/ChatRoomService.java
@@ -9,6 +9,7 @@ import com.ureca.ufit.domain.chatbot.repository.ChatRoomRepository;
 import com.ureca.ufit.domain.user.repository.UserRepository;
 import com.ureca.ufit.entity.ChatRoom;
 import com.ureca.ufit.entity.User;
+import com.ureca.ufit.global.auth.details.CustomUserDetails;
 
 import lombok.RequiredArgsConstructor;
 
@@ -16,19 +17,17 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ChatRoomService {
 
-	private static final String ANONYMOUS_USER = "anonymousUser";
-
 	private final ChatRoomRepository chatRoomRepository;
 	private final UserRepository userRepository;
 
 	@Transactional
-	public ChatRoomCreateResponse getOrCreateChatRoom(String email) {
-		if (ANONYMOUS_USER.equals(email)) {
+	public ChatRoomCreateResponse getOrCreateChatRoom(CustomUserDetails userDetails) {
+		if (userDetails == null) {
 			ChatRoom newChatRoom = chatRoomRepository.save(ChatRoom.of(null));
 			return ChatRoomMapper.toChatroomCreateResponse(newChatRoom);
 		}
 
-		User findUser = userRepository.getByEmail(email);
+		User findUser = userRepository.getByEmail(userDetails.email());
 		return chatRoomRepository.findByUser(findUser)
 			.map(ChatRoomMapper::toChatroomCreateResponse)
 			.orElseGet(() -> {

--- a/src/test/java/com/ureca/ufit/chatbot/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/ureca/ufit/chatbot/service/ChatRoomServiceTest.java
@@ -20,6 +20,8 @@ import com.ureca.ufit.domain.chatbot.service.ChatRoomService;
 import com.ureca.ufit.domain.user.repository.UserRepository;
 import com.ureca.ufit.entity.ChatRoom;
 import com.ureca.ufit.entity.User;
+import com.ureca.ufit.entity.enums.Role;
+import com.ureca.ufit.global.auth.details.CustomUserDetails;
 
 @ExtendWith(MockitoExtension.class)
 public class ChatRoomServiceTest {
@@ -47,7 +49,8 @@ public class ChatRoomServiceTest {
 		given(chatRoomRepository.findByUser(user)).willReturn(Optional.of(existingChatRoom));
 
 		// when
-		ChatRoomCreateResponse result = chatRoomService.getOrCreateChatRoom(email);
+		ChatRoomCreateResponse result = chatRoomService.getOrCreateChatRoom(
+			new CustomUserDetails(1L, email, "pass", Role.USER));
 
 		// then
 		assertThat(result.chatRoomId()).isEqualTo(chatRoomId);
@@ -70,7 +73,8 @@ public class ChatRoomServiceTest {
 		given(chatRoomRepository.save(any(ChatRoom.class))).willReturn(newChatRoom);
 
 		// when
-		ChatRoomCreateResponse result = chatRoomService.getOrCreateChatRoom(email);
+		ChatRoomCreateResponse result = chatRoomService.getOrCreateChatRoom(
+			new CustomUserDetails(1L, email, "pass", Role.USER));
 
 		// then
 		assertThat(result.chatRoomId()).isEqualTo(chatRoomId);
@@ -82,14 +86,13 @@ public class ChatRoomServiceTest {
 	@DisplayName("비회원 사용자인 경우 새 채팅방을 생성하고 isAnonymous가 true인 응답을 반환한다")
 	public void getOrCreateChatRoom_AnonymousUser() {
 		// given
-		String email = "anonymousUser";
 		Long chatRoomId = 3L;
 
 		ChatRoom anonymousChatRoom = ChatRoomFixture.chatRoom(chatRoomId, null);
 		given(chatRoomRepository.save(any(ChatRoom.class))).willReturn(anonymousChatRoom);
 
 		// when
-		ChatRoomCreateResponse result = chatRoomService.getOrCreateChatRoom(email);
+		ChatRoomCreateResponse result = chatRoomService.getOrCreateChatRoom(null);
 
 		// then
 		assertThat(result.chatRoomId()).isEqualTo(chatRoomId);


### PR DESCRIPTION
email이 "anonymous" -> userDetails가 null

## 🔥 Related Issue

- Close #61 


## 📑 Task

- 인증객체가 userDetails로 수정됨에 따라 비회원 조건이 userDetails가 null인 경우로 수정

## 🔍 To Reviewer

- 집중적으로 리뷰해야될 부분 있으면 작성
