### PR TITLE
[Fix] 요금제 삭제 로직 수정

### DIFF
--- a/src/main/java/com/ureca/ufit/domain/admin/service/AdminService.java
+++ b/src/main/java/com/ureca/ufit/domain/admin/service/AdminService.java
@@ -53,6 +53,16 @@ public class AdminService {
 		RatePlan ratePlan = ratePlanRepository.findById(ratePlanId)
 			.orElseThrow(() -> new RestApiException(RatePlanErrorCode.RATE_PLAN_NOT_FOUND)
 			);
+
+		long subscriberCount = userRepository.countByRatePlanId(ratePlanId);
+
+		if (ratePlan.isEnabled()) {
+			throw new RestApiException(RatePlanErrorCode.CANNOT_DELETE_WHILE_ENABLED);
+		}
+		if (subscriberCount > 0) {
+			throw new RestApiException(RatePlanErrorCode.CANNOT_DELETE_WITH_SUBSCRIBERS);
+		}
+
 		ratePlan.updateDeleteStatus();
 		ratePlanRepository.save(ratePlan);
 

--- a/src/main/java/com/ureca/ufit/domain/rateplan/exception/RatePlanErrorCode.java
+++ b/src/main/java/com/ureca/ufit/domain/rateplan/exception/RatePlanErrorCode.java
@@ -10,7 +10,9 @@ import lombok.Getter;
 public enum RatePlanErrorCode implements ErrorCode {
 
 	RATE_PLAN_NOT_FOUND("해당 ratePlanId의 요금제를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-	RATE_PLAN_ALREADY_DELETED("이미 삭제된 요금제입니다.", HttpStatus.BAD_REQUEST);
+	RATE_PLAN_ALREADY_DELETED("이미 삭제된 요금제입니다.", HttpStatus.BAD_REQUEST),
+	CANNOT_DELETE_WHILE_ENABLED("판매중인 요금제는 삭제할 수 없습니다.", HttpStatus.BAD_REQUEST),
+	CANNOT_DELETE_WITH_SUBSCRIBERS("사용자가 있는 요금제는 삭제할 수 없습니다.", HttpStatus.BAD_REQUEST);
 
 	private final String message;
 	private final HttpStatus httpStatus;

--- a/src/main/java/com/ureca/ufit/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/ureca/ufit/domain/user/repository/UserRepository.java
@@ -19,6 +19,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
 		return findByEmail(email).orElseThrow(() -> new RestApiException(UserErrorCode.USER_NOT_FOUND));
 	}
 
+	long countByRatePlanId(String ratePlanId);
+
 	@Query("SELECT u.ratePlanId AS ratePlanId, COUNT(u) AS count " +
 			"FROM User u GROUP BY u.ratePlanId")
 	List<RatePlanCountProjection> countUsersByRatePlan();

--- a/src/test/java/com/ureca/ufit/admin/service/AdminServiceTest.java
+++ b/src/test/java/com/ureca/ufit/admin/service/AdminServiceTest.java
@@ -3,6 +3,8 @@ package com.ureca.ufit.admin.service;
 import static org.assertj.core.api.Assertions.*;import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
+import java.util.Optional;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,19 +14,26 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.ureca.ufit.common.fixture.RatePlanFixture;
+import com.ureca.ufit.domain.admin.dto.response.DeleteRatePlanResponse;
 import com.ureca.ufit.domain.admin.dto.response.RatePlanStatusResponse;
 import com.ureca.ufit.domain.admin.service.AdminService;
 import com.ureca.ufit.domain.chatbot.repository.ChatBotReviewRepository;
 import com.ureca.ufit.domain.rateplan.exception.RatePlanErrorCode;
 import com.ureca.ufit.domain.rateplan.repository.RatePlanRepository;
+import com.ureca.ufit.domain.user.repository.UserRepository;
 import com.ureca.ufit.entity.RatePlan;
 import com.ureca.ufit.global.exception.RestApiException;
 
 @ExtendWith(MockitoExtension.class)
 class AdminServiceTest {
 
+	private static final String PLAN_ID = "plan-123";
+
 	@Mock
 	RatePlanRepository ratePlanRepository;
+
+	@Mock
+	UserRepository userRepository;
 
 	@Mock
 	ChatBotReviewRepository chatBotReviewRepository;
@@ -71,4 +80,24 @@ class AdminServiceTest {
 			.isInstanceOf(RestApiException.class)
 			.hasMessage(RatePlanErrorCode.RATE_PLAN_ALREADY_DELETED.getMessage());
   }
+
+  	@DisplayName("판매중지이며 가입자가 한 명도 없을 때 요금제를 삭제한다.")
+	@Test
+	void deleteRatePlan() {
+		// given
+		RatePlan plan = RatePlanFixture.ratePlan("테스트플랜", false, false);
+		ReflectionTestUtils.setField(plan, "id", PLAN_ID);
+		given(ratePlanRepository.findById(PLAN_ID)).willReturn(Optional.of(plan));
+		given(userRepository.countByRatePlanId(PLAN_ID)).willReturn(0L);
+
+		// when
+		DeleteRatePlanResponse response = adminService.deleteRatePlan(PLAN_ID);
+
+		// then
+		assertThat(response.message())
+			.isEqualTo("요금제가 성공적으로 삭제되었습니다.");
+		assertThat(plan.isDeleted()).isTrue();
+
+	}
+
 }


### PR DESCRIPTION
## 🔥 Related Issue

- Close #36 


## 📑 Task

- [] 판매중이 아니며 가입자가 한명도 없을때만 삭제 가능하도록 로직 수정
- 


## 🔍 To Reviewer

- 집중적으로 리뷰해야될 부분 있으면 작성
