### PR TITLE
fix: 챗봇 리뷰 저장 채팅방 및 추천 메시지 매핑

### DIFF
--- a/src/main/java/com/ureca/ufit/domain/chatbot/service/ChatBotMessageService.java
+++ b/src/main/java/com/ureca/ufit/domain/chatbot/service/ChatBotMessageService.java
@@ -68,7 +68,7 @@ public class ChatBotMessageService {
 	}
 
 	public void validateMessageBelongsToChatRoom(String chatBotMessage, Long chatRoomId) {
-		if (chatBotMessageRepository.existsByIdAndChatRoomId(chatBotMessage, chatRoomId)) {
+		if (!chatBotMessageRepository.existsByIdAndChatRoomId(chatBotMessage, chatRoomId)) {
 			throw new RestApiException(ChatBotErrorCode.INVALID_CHATBOT_MESSAGE);
 		}
 	}


### PR DESCRIPTION
## 🔥 Related Issue

- Close #98 


## 📑 Task

- 챗봇 리뷰 저장 시 채팅방 번호 및 추천 메시지가 매핑 되었을 때 예외가 발생하는 오류 수정


## 🔍 To Reviewer

- 집중적으로 리뷰해야될 부분 있으면 작성
