### PR TITLE
[Fix] null-safe 매핑 적용

### DIFF
--- a/src/main/java/com/ureca/ufit/domain/rateplan/dto/response/RatePlanDetailResponse.java
+++ b/src/main/java/com/ureca/ufit/domain/rateplan/dto/response/RatePlanDetailResponse.java
@@ -3,7 +3,7 @@ package com.ureca.ufit.domain.rateplan.dto.response;
 import java.util.Map;
 
 public record RatePlanDetailResponse(
-	String id,
+	String ratePlanId,
 	String planName,
 	String summary,
 	int monthlyFee,

--- a/src/main/java/com/ureca/ufit/domain/rateplan/repository/RatePlanQueryRepositoryImpl.java
+++ b/src/main/java/com/ureca/ufit/domain/rateplan/repository/RatePlanQueryRepositoryImpl.java
@@ -186,10 +186,10 @@ public class RatePlanQueryRepositoryImpl implements RatePlanQueryRepository {
 		pipeline.add(Aggregation.limit(pageable.getPageSize()));
 
 		AggregationOperation project = Aggregation.project()
-			.and("_id").as("id")
+			.and("_id").as("ratePlanId")
 			.and("plan_name").as("planName")
 			.and("monthly_fee").as("monthlyFee")
-			.and("discount_fee").as("discountFee");
+			.and(ifNull("discount_fee").then(0)).as("discountFee");
 		pipeline.add(project);
 
 		List<RatePlanPreviewResponse> results = mongoTemplate.aggregate(
@@ -211,11 +211,11 @@ public class RatePlanQueryRepositoryImpl implements RatePlanQueryRepository {
 		pipeline.add(Aggregation.match(criteria));
 
 		AggregationOperation project = Aggregation.project()
-			.and("_id").as("id")
+			.and("_id").as("ratePlanId")
 			.and("plan_name").as("planName")
 			.and("summary").as("summary")
 			.and("monthly_fee").as("monthlyFee")
-			.and("discount_fee").as("discountFee")
+			.and(ifNull("discount_fee").then((Integer)null)).as("discountFee")
 			.and("data_allowance").as("dataAllowance")
 			.and("voice_allowance").as("voiceAllowance")
 			.and("sms_allowance").as("smsAllowance")


### PR DESCRIPTION
## 🔥 Related Issue

- Close #112 


## 📑 Task

- Aggregation에서 _id → ratePlanId로 매핑 필드명 변경
- RatePlanPreviewResponse: discount_fee가 없을 때 기본값 0으로 null-safe 처리

## 🔍 To Reviewer
