### PR TITLE
fix: access token 만료 시 토큰 재발급이 되는 문제

### DIFF
--- a/src/main/java/com/ureca/ufit/global/auth/handler/CustomLogoutHandler.java
+++ b/src/main/java/com/ureca/ufit/global/auth/handler/CustomLogoutHandler.java
@@ -47,22 +47,28 @@ public class CustomLogoutHandler implements LogoutHandler {
 			// 블랙 리스트에 어세스 토큰 추가
 			addToBlacklistRedis(accessToken);
 
+		} catch (RestApiException e) {
+			// 만료된 토큰
+			if( !e.getErrorCode().equals(CommonErrorCode.EXPIRED_TOKEN)) {
+				try {
+					SendErrorResponseUtil.sendErrorResponse(response, e.getErrorCode());
+				} catch (IOException ex) {
+					throw new RuntimeException(ex);
+				}
+			}
+		} finally {
+			// 쿠키에서 리프레시 토큰 삭제 (timeout을 0으로 두어 즉시 삭제)
+			JwtUtil.updateRefreshTokenCookie(response, null, 0);
+
 			// 레디스에서 리프레시 토큰 삭제
 			String refreshToken = JwtUtil.getRefreshTokenCookies(request);
+
 			if (refreshToken != null) {
 				// Redis에서 해당 리프레시 토큰 키 삭제
 				refreshTokenRepository.findById(refreshToken)
-					.ifPresent(refreshTokenRepository::delete);
+						.ifPresent(refreshTokenRepository::delete);
 			}
 
-			// 쿠키에서 리프레시 토큰 삭제 (timeout을 0으로 두어 즉시 삭제)
-			JwtUtil.updateRefreshTokenCookie(response, null, 0);
-		} catch (RestApiException e) {
-			try {
-				SendErrorResponseUtil.sendErrorResponse(response, e.getErrorCode());
-			} catch (IOException ex) {
-				throw new RuntimeException(ex);
-			}
 		}
 	}
 

--- a/src/main/java/com/ureca/ufit/global/auth/handler/CustomLogoutHandler.java
+++ b/src/main/java/com/ureca/ufit/global/auth/handler/CustomLogoutHandler.java
@@ -54,8 +54,8 @@ public class CustomLogoutHandler implements LogoutHandler {
 					throw e;
 			}
 
+			String	refreshToken = JwtUtil.getRefreshTokenCookies(request);
 			// 쿠키에서 리프레시 토큰 삭제 (timeout을 0으로 두어 즉시 삭제)
-			String refreshToken = JwtUtil.getRefreshTokenCookies(request);
 			JwtUtil.updateRefreshTokenCookie(response, null, 0);
 
 			// Redis에서 해당 리프레시 토큰 키 삭제
@@ -66,6 +66,9 @@ public class CustomLogoutHandler implements LogoutHandler {
 			);
 
 		} catch (RestApiException e) {
+			// 쿠키나 레디스에서 리프레시 토큰을 찾지 못했을 경우 정상처리
+			if(e.getErrorCode().equals(CommonErrorCode.REFRESH_NOT_FOUND))
+				return;
 			try {
 				SendErrorResponseUtil.sendErrorResponse(response, e.getErrorCode());
 			} catch (IOException ex) {

--- a/src/main/java/com/ureca/ufit/global/auth/handler/CustomLogoutHandler.java
+++ b/src/main/java/com/ureca/ufit/global/auth/handler/CustomLogoutHandler.java
@@ -42,33 +42,35 @@ public class CustomLogoutHandler implements LogoutHandler {
 				throw new RestApiException(CommonErrorCode.NOT_EXIST_BEARER_SUFFIX);
 			}
 			String accessToken = bearerToken.substring(BEARER_PREFIX.length());
-			JwtUtil.validateAccessToken(accessToken, secretKey);
 
-			// 블랙 리스트에 어세스 토큰 추가
-			addToBlacklistRedis(accessToken);
+			try {
+				JwtUtil.validateAccessToken(accessToken, secretKey);
 
-		} catch (RestApiException e) {
-			// 만료된 토큰
-			if( !e.getErrorCode().equals(CommonErrorCode.EXPIRED_TOKEN)) {
-				try {
-					SendErrorResponseUtil.sendErrorResponse(response, e.getErrorCode());
-				} catch (IOException ex) {
-					throw new RuntimeException(ex);
-				}
+				// 블랙 리스트에 어세스 토큰 추가
+				addToBlacklistRedis(accessToken);
+			} catch (RestApiException e) {
+				// 어세스토큰 만료는 정상 처리
+				if( !e.getErrorCode().equals(CommonErrorCode.EXPIRED_TOKEN))
+					throw e;
 			}
-		} finally {
+
 			// 쿠키에서 리프레시 토큰 삭제 (timeout을 0으로 두어 즉시 삭제)
+			String refreshToken = JwtUtil.getRefreshTokenCookies(request);
 			JwtUtil.updateRefreshTokenCookie(response, null, 0);
 
-			// 레디스에서 리프레시 토큰 삭제
-			String refreshToken = JwtUtil.getRefreshTokenCookies(request);
+			// Redis에서 해당 리프레시 토큰 키 삭제
+			refreshTokenRepository.delete(
+				refreshTokenRepository.findById(refreshToken).orElseThrow( () ->
+						new RestApiException(CommonErrorCode.REFRESH_NOT_FOUND)
+				)
+			);
 
-			if (refreshToken != null) {
-				// Redis에서 해당 리프레시 토큰 키 삭제
-				refreshTokenRepository.findById(refreshToken)
-						.ifPresent(refreshTokenRepository::delete);
+		} catch (RestApiException e) {
+			try {
+				SendErrorResponseUtil.sendErrorResponse(response, e.getErrorCode());
+			} catch (IOException ex) {
+				throw new RuntimeException(ex);
 			}
-
 		}
 	}
 

--- a/src/main/java/com/ureca/ufit/global/auth/util/JwtUtil.java
+++ b/src/main/java/com/ureca/ufit/global/auth/util/JwtUtil.java
@@ -42,8 +42,8 @@ public class JwtUtil {
 	public static final String COOKIE_HEADER_NAME = "Set-Cookie";
 	public static final String COOKIE_SAME_SITE_STRATEGY = "Lax";
 
-	public static final int ACCESS_TOKEN_EXPIRED_MS = 1000 * 60 * 30; // 30분
-	public static final int REFRESH_TOKEN_EXPIRED_MS = 1000 * 60 * 60 * 24 * 3; // 3일
+	public static final int ACCESS_TOKEN_EXPIRED_MS = 1000*13;//1000 * 60 * 30; // 30분
+	public static final int REFRESH_TOKEN_EXPIRED_MS = 1000*15;//1000 * 60 * 60 * 24 * 3; // 3일
 
 	public static String createToken(String email, String type, SecretKey secretKey, long expiresIn) {
 		return Jwts.builder()
@@ -155,7 +155,7 @@ public class JwtUtil {
 		Cookie[] cookies = request.getCookies();
 
 		if (cookies == null)
-			throw new RestApiException(CommonErrorCode.REFRESH_DENIED);
+			throw new RestApiException(CommonErrorCode.REFRESH_NOT_FOUND);
 
 		for (Cookie cookie : cookies) {
 			if (REFRESH_TOKEN_COOKIE_NAME.equals(cookie.getName())) {
@@ -163,7 +163,7 @@ public class JwtUtil {
 			}
 		}
 
-		throw new RestApiException(CommonErrorCode.REFRESH_DENIED);
+		throw new RestApiException(CommonErrorCode.REFRESH_NOT_FOUND);
 	}
 
 }

--- a/src/main/java/com/ureca/ufit/global/auth/util/JwtUtil.java
+++ b/src/main/java/com/ureca/ufit/global/auth/util/JwtUtil.java
@@ -42,8 +42,8 @@ public class JwtUtil {
 	public static final String COOKIE_HEADER_NAME = "Set-Cookie";
 	public static final String COOKIE_SAME_SITE_STRATEGY = "Lax";
 
-	public static final int ACCESS_TOKEN_EXPIRED_MS = 1000*13;//1000 * 60 * 30; // 30분
-	public static final int REFRESH_TOKEN_EXPIRED_MS = 1000*15;//1000 * 60 * 60 * 24 * 3; // 3일
+	public static final int ACCESS_TOKEN_EXPIRED_MS = 1000 * 60 * 30; // 30분
+	public static final int REFRESH_TOKEN_EXPIRED_MS = 1000 * 60 * 60 * 24 * 3; // 3일
 
 	public static String createToken(String email, String type, SecretKey secretKey, long expiresIn) {
 		return Jwts.builder()


### PR DESCRIPTION
## 🔥 Related Issue

- Close #127 


## 📑 Task

- 로그아웃 요청 시, Access Token이 만료된 경우에도 정상적인 요청으로 간주하고 처리 흐름을 중단하지 않음
- 만료된 토큰이더라도 RefreshToken과 AccessToken을 모두 삭제하여 보안성을 유지
- 이 경우 에러 응답은 반환하지 않고, 쿠키/Redis 정리만 수행하여 사용자 기준 정상 로그아웃으로 처리

## 🔍 To Reviewer
