### PR TITLE
fix: AdminRatePlanResponse 필드 원시타입 -> 참조 타입으로 변경

### DIFF
--- a/src/main/java/com/ureca/ufit/domain/admin/dto/response/AdminRatePlanResponse.java
+++ b/src/main/java/com/ureca/ufit/domain/admin/dto/response/AdminRatePlanResponse.java
@@ -7,16 +7,16 @@ public record AdminRatePlanResponse(
 	String ratePlanId,
 	String planName,
 	String summary,
-	int monthlyFee,
-	int discountFee,
+	Integer monthlyFee,
+	Integer discountFee,
 	String dataAllowance,
 	String voiceAllowance,
 	String smsAllowance,
 	Map<String, Object> basicBenefit,
 	Map<String, Object> specialBenefit,
 	Map<String, Object> discountBenefit,
-	boolean isEnabled,
-	boolean isDeleted,
+	Boolean isEnabled,
+	Boolean isDeleted,
 	LocalDateTime createdAt
 ) {
 }


### PR DESCRIPTION
## 🔥 Related Issue

- Close #130 


## 📑 Task

-  AdminRatePlanResponse 필드 원시타입 -> 참조 타입으로 변경


## 🔍 To Reviewer

- 집중적으로 리뷰해야될 부분 있으면 작성
